### PR TITLE
Send Mail Support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,5 +22,8 @@ Imports:
   lifecycle
 Suggests:
   testthat,
-  withr
+  withr,
+  knitr,
+  rmarkdown
+VignetteBuilder: knitr
 URL: https://datagration.github.io/petrovisor-r-api/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Myrconn.PetroVisor.Client
 Type: Package
 Title: Wrapper for PetroVisor's API
-Version: 3.6.0
+Version: 3.6.0.9000
 Authors@R: c(
   person("Andreas", "Schweiger", email = "andreas.schweiger@weatherford.com", role = c("aut", "cre")),
   person("Ramez", "Abdalla", email = "ramez.abdalla@weatherford.com", role = "aut"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # Myrconn.PetroVisor.Client (development version)
 
 * add `send_mail()` method to `ServiceProvider` class for sending emails using PetroVisor email configuration
+* deprecate `DataSetRequest` class - never integrated into DataServices, use DataServices methods directly instead
+* add comprehensive documentation with @seealso cross-references and vignette integration across all major classes
 
 # Myrconn.PetroVisor.Client 3.6.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Myrconn.PetroVisor.Client (development version)
+
+* add `send_mail()` method to `ServiceProvider` class for sending emails using PetroVisor email configuration
+
 # Myrconn.PetroVisor.Client 3.6.0
 
 * implement singleton authentication pattern via `AuthContext` class for centralized auth management

--- a/R/ApiRequests.R
+++ b/R/ApiRequests.R
@@ -138,7 +138,7 @@ ApiRequests <- R6Class("ApiRequests", # nolint: object_name_linter
 
       # get auth
       auth <- get_auth_context()$get_auth()
-      url <- auth$workspace_data_url
+      url <- if (is.null(url)) auth$workspace_data_url else url
       token_type <- auth$token_type
       token <- auth$token
       # build url
@@ -156,7 +156,7 @@ ApiRequests <- R6Class("ApiRequests", # nolint: object_name_linter
 
       httr::stop_for_status(ret, task = paste("GET with result:", ret))
 
-      cont <- httr::content(ret, as = "text")
+      cont <- httr::content(ret, as = "text", encoding = "UTF-8")
 
       if (parse_json) {
         return(jsonlite::fromJSON(cont))

--- a/R/AuthContext.R
+++ b/R/AuthContext.R
@@ -13,6 +13,15 @@ library("R6")
 #'
 #' @export AuthContext
 #'
+#' @seealso
+#' * [ServiceProvider] for creating authenticated sessions
+#' * [AuthenticationService] for authentication methods
+#' * [get_auth_context()] for accessing the singleton instance
+#' * [with_auth_context()] for executing code with authentication
+#' * [require_authentication()] for checking authentication status
+#' * `vignette("authentication")` for authentication examples
+#' * `vignette("getting-started")` for setup guide
+#'
 #' @examples
 #' \dontrun{
 #' # Get the singleton instance

--- a/R/AuthenticationService.R
+++ b/R/AuthenticationService.R
@@ -4,7 +4,22 @@
 #' @description Provides methods for authenticating with the PetroVisor API.
 #'
 #' @details This class includes methods to obtain access tokens using various
-#' authentication mechanisms such as API keys, user credentials, and refresh tokens.
+#' authentication mechanisms such as API keys, user credentials, and refresh
+#' tokens.
+#'
+#' @seealso
+#' Related classes:
+#' * [ServiceProvider] for using tokens with the service provider
+#' * [AuthContext] for managing authentication context
+#'
+#' Authentication helpers:
+#' * [get_auth_context()] for accessing the global authentication context
+#' * [with_auth_context()] for executing code with specific authentication
+#' * [require_authentication()] for ensuring authentication is present
+#'
+#' Vignettes:
+#' * `vignette("authentication")` for comprehensive authentication guide
+#' * `vignette("getting-started")` for basic setup and usage
 #'
 #' @export
 #'
@@ -37,7 +52,7 @@ library(httr)
 library(jsonlite)
 library(base64enc)
 
-AuthenticationService <- R6::R6Class("AuthenticationService",
+AuthenticationService <- R6::R6Class("AuthenticationService", # nolint: object_name_linter
   public = list(
 
     # Method to get access token

--- a/R/Context.R
+++ b/R/Context.R
@@ -7,10 +7,10 @@ library("R6")
 #' @export Context
 #'
 #' @field name The name of the context.
-#' @field entity_set The context's entity set (object of class EntitySet).
-#' @field scope The context's scope (object of class Scope).
-#' @field hierarchy (Optional) The hierarchy used for automatic aggregation
-#'   (Object of type Hierarchy).
+#' @field entity_set The context's [EntitySet] defining which entities to
+#'   include.
+#' @field scope The context's [Scope] defining the time or depth range.
+#' @field hierarchy (Optional) The [Hierarchy] used for automatic aggregation.
 #' @field loading_scenario_name (Optional) The name of the loading scenario.
 #' @field saving_scenario_name (Optional) The name of the saving scenario.
 #' @field scenario_data_only (Optional) Whether to load data from the specified
@@ -19,6 +19,15 @@ library("R6")
 #' @field formula The context's definition as string (P# syntax).
 #' @field description The description of the item.
 #' @field labels A list of strings holding the labels of the context.
+#'
+#' @seealso
+#' * [Scope] for scope definitions
+#' * [EntitySet] for entity set definitions
+#' * [Hierarchy] for hierarchy definitions
+#' * [RepositoryService] for loading and saving contexts
+#' * [DataServices] for using contexts in data queries
+#' * `vignette("working-with-data")` for data examples
+#'
 #' @examples
 #' \dontrun{
 #' Context$new(name = "MyContext",
@@ -34,7 +43,7 @@ library("R6")
 #'                             end = "2020-03-01T00:00:00.000Z",
 #'                             time_increment = "Daily"))
 #' }
-Context <- R6Class("Context",
+Context <- R6Class("Context", # nolint: object_name_linter
   public = list(
     name = NULL,
     entity_set = NULL,
@@ -50,10 +59,11 @@ Context <- R6Class("Context",
     #' @description Create a new Context instance.
     #'
     #' @param name The name of the context.
-    #' @param entity_set The context's entity set (object of class EntitySet).
-    #' @param scope The context's scope (object of class Scope).
-    #' @param hierarchy (Optional) The hierarchy used for automatic aggregation
-    #'   (Object of type Hierarchy).
+    #' @param entity_set The context's [EntitySet] defining which entities to
+    #'   include.
+    #' @param scope The context's [Scope] defining the time or depth range.
+    #' @param hierarchy (Optional) The [Hierarchy] used for automatic
+    #'   aggregation.
     #' @param loading_scenario_name (Optional) The name of the loading scenario.
     #' @param saving_scenario_name (Optional) The name of the saving scenario.
     #' @param scenario_data_only (Optional) Whether to load data from the
@@ -85,7 +95,7 @@ Context <- R6Class("Context",
     },
 
     #' @details Convert the object to a list. This function is mainly used
-    #' by the RepositoryService to convert the objects to lists and then
+    #' by the [RepositoryService] to convert the objects to lists and then
     #' call the web API.
     toList = function() {
       dl <- list(

--- a/R/DataServices.R
+++ b/R/DataServices.R
@@ -32,6 +32,28 @@ library("R6")
 #'   \item{Pivot Tables}{Pre-aggregated summary tables.}
 #' }
 #'
+#' @seealso
+#' Related classes:
+#' * [ServiceProvider] for creating a service provider instance
+#' * [RepositoryService] for managing entities and signals
+#'
+#' Data type classes:
+#' * [StaticData] for static data structure
+#' * [TimeData] for time series data structure
+#' * [DepthData] for depth data structure
+#' * [PVTData] for PVT data structure
+#' * [ReferenceTable] for reference table structure
+#' * [PivotTable] for pivot table structure
+#'
+#' Related objects:
+#' * [Signal] for signal definitions
+#' * [Entity] for entity definitions
+#' * [Unit] for unit definitions
+#'
+#' Vignettes:
+#' * `vignette("working-with-data")` for comprehensive data operations guide
+#' * `vignette("getting-started")` for basic usage
+#'
 #' @export DataServices
 #'
 #' @examples \dontrun{
@@ -92,9 +114,9 @@ DataServices <- R6Class(  # nolint: object_name_linter
   public = list(
 
     #' @description Create a new DataServices instance. This is done by the
-    #' ServiceProvider automatically.
+    #' [ServiceProvider] automatically.
     #'
-    #' @param sp instance of the service provider
+    #' @param sp Instance of the [ServiceProvider]
     initialize = function(sp) {
       private$sp <- sp
     },
@@ -103,12 +125,12 @@ DataServices <- R6Class(  # nolint: object_name_linter
     #' @param entities List of entities to retrieve data for. Can be:
     #'   \itemize{
     #'     \item Character vector: \code{c("Well_001", "Well_002")}
-    #'     \item List of Entity objects: \code{list(entity1, entity2)}
+    #'     \item List of [Entity] objects: \code{list(entity1, entity2)}
     #'   }
-    #' @param signals List of parsed signal objects created using
+    #' @param signals List of parsed [Signal] objects created using
     #'   \code{sp$parse_signal()}. Each signal should specify name and unit.
     #' @param scenario_names List of scenario names to load data for.
-    #' @param hierarchy_name Hierarchy used in the data retrieval process.
+    #' @param hierarchy_name [Hierarchy] used in the data retrieval process.
     #' @param top_records Number of records to return.
     #' @param include_workspace_data Whether workspace data shall be included in
     #'   the output (only applies if scenarios are used). Defaults to
@@ -138,7 +160,7 @@ DataServices <- R6Class(  # nolint: object_name_linter
     #'   time_data <- sp$data$load(
     #'     entities = c("Well_A"),
     #'     signals = lapply(
-    #'       c("oil production [bbl/d]", "gas production [mcf/d]"),
+    #'       c("oil production [bbl/d]", "gas production [MSCF/d]"),
     #'       function(x) { sp$parse_signal(x) }
     #'     ),
     #'     time_increment = "Daily",
@@ -597,7 +619,7 @@ DataServices <- R6Class(  # nolint: object_name_linter
     #'     data_type = "StaticNumeric",
     #'     data = static_numeric_data,
     #'     signals = lapply(
-    #'       c("initial oil reserves [bbl]", "initial gas reserves [mcf]"),
+    #'       c("initial oil reserves [bbl]", "initial gas reserves [MSCF]"),
     #'       function(x) { sp$parse_signal(x) }
     #'     ),
     #'     generate_logs = TRUE,
@@ -636,7 +658,7 @@ DataServices <- R6Class(  # nolint: object_name_linter
     #'     data_type = "TimeNumeric",
     #'     data = time_numeric_data,
     #'     signals = lapply(
-    #'       c("oil rate [bbl/d]", "gas rate [mcf/d]"),
+    #'       c("oil rate [bbl/d]", "gas rate [MSCF/d]"),
     #'       function(x) { sp$parse_signal(x) }
     #'     ),
     #'     values_time_increment = "Daily"

--- a/R/DataSetRequest.R
+++ b/R/DataSetRequest.R
@@ -2,47 +2,91 @@ library("R6")
 
 #' @title DataSetRequest
 #'
-#' @description Class representing a PetroVisor dataset request object.
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
+#' Class representing a PetroVisor dataset request object.
+#'
+#' **This class is deprecated and no longer used.** It was originally designed
+#' for use with DataServices but was never integrated into the actual
+#' implementation. DataServices uses direct parameter passing instead.
+#'
+#' This class is retained only for backwards compatibility and may be removed
+#' in a future version.
 #'
 #' @export DataSetRequest
 #'
-#' @field entityName The name of the entity for which data is requested.
-#' @field signalName The name of the requested signal.
-#' @field unitName The name of the unit the data is requested in.
+#' @field entityName The name of the [Entity] for which data is requested.
+#' @field signalName The name of the requested [Signal].
+#' @field unitName The name of the [Unit] the data is requested in.
+#'
+#' @seealso
+#' * [DataServices] for loading data (does not use DataSetRequest)
+#' * [Entity] for entity definitions
+#' * [Signal] for signal definitions
+#' * [Unit] for unit definitions
+#' * `vignette("working-with-data")` for data loading examples
 #'
 #' @examples
 #' \dontrun{
+#' # DEPRECATED: This class is not used by DataServices
 #' DataSetRequest$new(entityName = "Well01",
 #'                    signalName = "surface x-coordinate",
 #'                    unitName = "m")
 #'}
-DataSetRequest <- R6Class("DataSetRequest",
+DataSetRequest <- R6Class("DataSetRequest", # nolint: object_name_linter
   public = list(
     entityName = NULL,
     signalName = NULL,
     unitName = NULL,
 
-    #' @description Create a new DataSetRequest instance.
+    #' @description
+    #' `r lifecycle::badge("deprecated")`
     #'
-    #' @param entityName The name of the entity for which data is requested.
-    #' @param signalName The name of the requested signal.
-    #' @param unitName The name of the unit the data is requested in.
+    #' Create a new DataSetRequest instance.
+    #'
+    #' **Deprecated:** This class is not used by DataServices and will be
+    #' removed in a future version.
+    #'
+    #' @param entityName The name of the [Entity] for which data is requested.
+    #' @param signalName The name of the requested [Signal].
+    #' @param unitName The name of the [Unit] the data is requested in.
     initialize = function(entityName = NULL,
                           signalName = NULL,
-                          unitName = NULL){
+                          unitName = NULL) {
+      lifecycle::deprecate_warn(
+        when = "3.6.0",
+        what = "DataSetRequest$new()",
+        details = paste(
+          "DataSetRequest is not used by DataServices.",
+          "Use DataServices methods directly with entity names,",
+          "signal names, and unit names as parameters."
+        )
+      )
       self$entityName <- entityName
       self$signalName <- signalName
       self$unitName <- unitName
     },
 
-    #' @description Convert the object to a list. This function is mainly used
-    #' by the DataServices to convert the objects to lists and then
+    #' @description
+    #' `r lifecycle::badge("deprecated")`
+    #'
+    #' Convert the object to a list. This function is mainly used
+    #' by [DataServices] to convert the objects to lists and then
     #' call the web API.
-    toList = function(){
+    #'
+    #' **Deprecated:** This method is not used by DataServices.
+    toList = function() {
+      lifecycle::deprecate_warn(
+        when = "3.6.0",
+        what = "DataSetRequest$toList()",
+        details = "DataSetRequest is deprecated and not used by DataServices."
+      )
       dl <- list(
-        Entity = if(is.null(self$entityName)) "" else self$entityName,
-        Signal = if(is.null(self$signalName)) "" else self$signalName,
-        Unit = if(is.null(self$unitName)) "" else self$unitName)
+        Entity = if (is.null(self$entityName)) "" else self$entityName,
+        Signal = if (is.null(self$signalName)) "" else self$signalName,
+        Unit = if (is.null(self$unitName)) "" else self$unitName
+      )
       return(dl)
     }
   )

--- a/R/DataTypes.R
+++ b/R/DataTypes.R
@@ -76,7 +76,7 @@ StaticData <- R6Class("StaticData",
 #'
 #' @examples
 #' \dontrun{
-#' TimeData$new(singal_name = "produced oil per time increment",
+#' TimeData$new(signal_name = "produced oil per time increment",
 #'              entity_name = "Well01",
 #'              unit_name = "m3",
 #'              data = list(list(Date = "2020-01-01T00:00:00.000Z",
@@ -139,7 +139,7 @@ TimeData <- R6Class("TimeData",
 #'
 #' @examples
 #' \dontrun{
-#' TimeData$new(singal_name = "produced oil per depth increment",
+#' TimeData$new(signal_name = "produced oil per depth increment",
 #'              entity_name = "Well01",
 #'              unit_name = "m3",
 #'              data = list(list(Depth = 100,
@@ -203,7 +203,7 @@ DepthData <- R6Class("DepthData",
 #'
 #' @examples
 #' \dontrun{
-#' PVTData$new(singal_name = "produced oil per time increment pvt",
+#' PVTData$new(signal_name = "produced oil per time increment pvt",
 #'             entity_name = "Well01",
 #'             unit_name = "m3",
 #'             data = list(list(Pressure = 300,

--- a/R/Entity.R
+++ b/R/Entity.R
@@ -11,6 +11,13 @@ library("R6")
 #' @field alias The alias of the entity.
 #' @field is_opportunity Whether the entity is an opportunity or not.
 #'
+#' @seealso
+#' * [RepositoryService] for loading and saving entities
+#' * [EntitySet] for grouping entities
+#' * [EntityType] for entity type definitions
+#' * [DataServices] for working with entity data
+#' * `vignette("repository-service")` for repository examples
+#'
 #' @examples
 #' \dontrun{
 #' Entity$new(
@@ -19,7 +26,7 @@ library("R6")
 #'   alias = "NewWellAlias",
 #'   is_opportunity = FALSE)
 #' }
-Entity <- R6Class("Entity",
+Entity <- R6Class("Entity", # nolint: object_name_linter
   public = list(
     name = NULL,
     entity_type_name = NULL,
@@ -44,7 +51,7 @@ Entity <- R6Class("Entity",
     },
 
     #' @details Convert the object to a list. This function is mainly used
-    #' by the RepositoryService to convert the objects to lists and then
+    #' by the [RepositoryService] to convert the objects to lists and then
     #' call the web API.
     toList = function() {
       dl <- list(

--- a/R/EntitySet.R
+++ b/R/EntitySet.R
@@ -7,10 +7,18 @@ library("R6")
 #' @export EntitySet
 #'
 #' @field name The name of the entity set.
-#' @field entities list of entity objects.
+#' @field entities List of [Entity] objects.
 #' @field formula The entity set's definition as string (P# syntax).
 #' @field description The description of the item.
 #' @field labels A list of strings holding the labels of the entity set.
+#'
+#' @seealso
+#' * [Entity] for entity definitions
+#' * [RepositoryService] for managing entity sets
+#' * [Scope] for time/depth filtering
+#' * [MLModel] for ML training context
+#' * `vignette("repository-service")` for examples
+#'
 #' @examples
 #' \dontrun{
 #' EntitySet$new(name = "MyEntities",
@@ -21,7 +29,7 @@ library("R6")
 #'                                       entity_type_name = "Well",
 #'                                       alias = "WellAlias2")))
 #' }
-EntitySet <- R6Class("EntitySet",
+EntitySet <- R6Class("EntitySet", # nolint: object_name_linter
   public = list(
     name = NULL,
     entities = NULL,
@@ -32,7 +40,7 @@ EntitySet <- R6Class("EntitySet",
     #' @description Create a new EntitySet instance.
     #'
     #' @param name The name of the entity set.
-    #' @param entities list of entity objects.
+    #' @param entities List of [Entity] objects.
     #' @param formula The entity set's definition as string (P# syntax).
     #' @param description The description of the item.
     #' @param labels A list of strings holding the labels of the entity set.
@@ -49,7 +57,7 @@ EntitySet <- R6Class("EntitySet",
     },
 
     #' @details Convert the object to a list. This function is mainly used
-    #' by the RepositoryService to convert the objects to lists and then
+    #' by the [RepositoryService] to convert the objects to lists and then
     #' call the web API.
     toList = function() {
       # create list from list of entities

--- a/R/EntityType.R
+++ b/R/EntityType.R
@@ -9,11 +9,16 @@ library("R6")
 #' @field name The name of the entity type.
 #' @field image The image of the entity type represented as string.
 #'
+#' @seealso
+#' * [Entity] for entity definitions
+#' * [RepositoryService] for loading entity types
+#' * `vignette("repository-service")` for examples
+#'
 #' @examples
 #' \dontrun{
 #' EntityType$new(name = "Section")
 #'}
-EntityType <- R6Class("EntityType",
+EntityType <- R6Class("EntityType", # nolint: object_name_linter
   public = list(
     name = NULL,
     image = NULL,

--- a/R/FileService.R
+++ b/R/FileService.R
@@ -8,6 +8,10 @@ library("R6")
 #' @details A new instance of this class will be created by the ServiceProvider
 #'  automatically.
 #'
+#' @seealso
+#' * [ServiceProvider] for accessing the file service via `sp$files`
+#' * `vignette("getting-started")` for basic usage
+#'
 #' @export FileService
 #'
 #' @examples \dontrun{
@@ -31,7 +35,7 @@ FileService <- R6Class( # nolint: object_name_linter
   public = list(
 
     #' @description Create a new FileService instance. This is done by the
-    #'  ServiceProvider automatically.
+    #'  [ServiceProvider] automatically.
     initialize = function() {},
 
     #' @description Retrieve the names of the files in the workspace's blob
@@ -110,8 +114,8 @@ FileService <- R6Class( # nolint: object_name_linter
     get_os = function() {
       sysinf <- Sys.info()
       if (!is.null(sysinf)) {
-        os <- sysinf['sysname']
-        if (os == 'Darwin')
+        os <- sysinf["sysname"]
+        if (os == "Darwin")
           os <- "osx"
       } else { ## mystery machine
         os <- .Platform$OS.type

--- a/R/Hierarchy.R
+++ b/R/Hierarchy.R
@@ -15,6 +15,13 @@ library("R6")
 #' @field time_stamp The (first) time stamp of the time dependent hierarchy.
 #' @field description The description of the item.
 #' @field labels A list of strings holding the labels of the scope.
+#'
+#' @seealso
+#' * [RepositoryService] for loading and saving hierarchies
+#' * [Context] for using hierarchies in data contexts
+#' * [Entity] for entity definitions
+#' * `vignette("repository-service")` for hierarchy examples
+#'
 #' @examples
 #' \dontrun{
 #' Hierarchy$new(name = "MyHierarchy",
@@ -22,7 +29,7 @@ library("R6")
 #'                                   Well2 = "Parent1",
 #'                                   Parent1 = NA))
 #'}
-Hierarchy <- R6Class("Hierarchy",
+Hierarchy <- R6Class("Hierarchy", # nolint: object_name_linter
   public = list(
     name = NULL,
     relationship = NULL,

--- a/R/LogEntry.R
+++ b/R/LogEntry.R
@@ -29,6 +29,11 @@ library("R6")
 #' @field message_details Optional details of the message.
 #' @field directory User directory (tenant).
 #'
+#' @seealso
+#' * [LoggingService] for saving and loading log entries
+#' * [ServiceProvider] for accessing the logging service
+#' * `vignette("getting-started")` for logging examples
+#'
 #' @examples
 #' \dontrun{
 #' LogEntry$new(category = "MyCategory",
@@ -36,7 +41,7 @@ library("R6")
 #'              message_details = "and here are some details",
 #'              severity = "Debug")
 #' }
-LogEntry <- R6Class("LogEntry",
+LogEntry <- R6Class("LogEntry", # nolint: object_name_linter
   public = list(
     timestamp = NULL,
     message = NULL,

--- a/R/LoggingService.R
+++ b/R/LoggingService.R
@@ -8,6 +8,11 @@ library("R6")
 #' @details A new instance of this class will be created by the ServiceProvider
 #' automatically.
 #'
+#' @seealso
+#' * [ServiceProvider] for accessing the logging service via `sp$logs`
+#' * [LogEntry] for log entry structure
+#' * `vignette("getting-started")` for basic usage
+#'
 #' @export LoggingService
 #'
 #' @examples \dontrun{
@@ -15,18 +20,18 @@ library("R6")
 #' sp <- ServiceProvider$new("Host", 8095, "WorkspaceA", "UserX", "Password")
 #'
 #' # get available categories
-#' availableCategories <- sp$logs$GetAvailableCategories()
+#' availableCategories <- sp$logs$load_categories()
 #'
 #' # get log entries
-#' allLogEntries <- sp$logs$GetLogEntries()
-#' warnings <- sp$logs$GetLogEntries(severity = "Warning")
-#' signIns <- sp$logs$GetLogEntries(category = "SignIn")
+#' allLogEntries <- sp$logs$load()
+#' warnings <- sp$logs$load(severities = "Warning")
+#' signIns <- sp$logs$load(categories = "SignIn")
 #'
 #' # add log entry
 #' entry <- LogEntry$new(message = "Test",
 #'                       category = "Tag",
 #'                       severity = "Information")
-#' sp$logs$AddLogEntry(entry)
+#' sp$logs$save(list(entry))
 #'
 #' # add several log entries at once
 #' entry1 <- LogEntry$new(message = "Test1",
@@ -35,10 +40,10 @@ library("R6")
 #' entry2 <- LogEntry$new(message = "Test2",
 #'                        category = "Tag",
 #'                        severity = "Information")
-#' sp$logs$AddLogEntries(list(entry1, entry2))
+#' sp$logs$save(list(entry1, entry2))
 #'
 #' # remove all log entries
-#' sp$logs$CleanUpLogEntries()
+#' sp$logs$delete(days_to_keep = 0)
 #' }
 LoggingService <- R6Class( # nolint: object_name_linter
   "LoggingService",
@@ -46,7 +51,7 @@ LoggingService <- R6Class( # nolint: object_name_linter
   public = list(
 
     #' @description Create a new LoggingService instance. This is done by
-    #'  the ServiceProvider automatically.
+    #'  the [ServiceProvider] automatically.
     #'
     #' @param url the URL for the API calls.
     #' @param token_type the type of the issued token.

--- a/R/MachineLearning.R
+++ b/R/MachineLearning.R
@@ -39,6 +39,16 @@ library("R6")
 #' @field test_scope_formula Test scope formula.
 #' @field test_entity_set_formula Test entity set formula.
 #'
+#' @seealso
+#' * [MlTrainingService] for training and managing ML models
+#' * [MLTrainingResult] for training results
+#' * [MLTrainingResults] for multiple training results
+#' * [MLTrainingOptions] for training configuration
+#' * [MLPreProcessor] for preprocessing methods
+#' * [Scope] for defining training context
+#' * [EntitySet] for entity filtering
+#' * `vignette("machine-learning")` for ML workflow examples
+#'
 #' @examples
 #' \dontrun{
 #' # Create a minimal ML model (Regression)

--- a/R/MlTrainingService.R
+++ b/R/MlTrainingService.R
@@ -8,6 +8,22 @@ library("R6")
 #'   publish trained models, and make predictions. It uses the singleton
 #'   AuthContext for authentication instead of requiring auth parameters.
 #'
+#' @seealso
+#' Related classes:
+#' * [ServiceProvider] for accessing the ML service via `sp$ml`
+#' * [MLModel] for model configuration
+#' * [MLTrainingOptions] for training configuration
+#' * [MLTrainingContext] for training context definitions
+#' * [MLTrainingFeature] for feature definitions
+#' * [MLTrainingOutcome] for outcome metric definitions
+#' * [MLTrainingResult] and [MLTrainingResults] for training results
+#' * [DataServices] for loading training data
+#' * [RepositoryService] for managing ML models
+#'
+#' Vignettes:
+#' * `vignette("machine-learning")` for comprehensive ML guide
+#' * `vignette("getting-started")` for basic usage
+#'
 #' @export MlTrainingService
 #'
 #' @examples
@@ -49,13 +65,13 @@ MlTrainingService <- R6Class( # nolint: object_name_linter
   public = list(
 
     #' @description Create a new MlTrainingService instance. This is done by
-    #'   the ServiceProvider automatically. The service uses the singleton
-    #'   AuthContext for authentication.
+    #'   the [ServiceProvider] automatically. The service uses the singleton
+    #'   [AuthContext] for authentication.
     initialize = function() {},
 
     #' @description Train machine learning models.
     #'
-    #' @param model An MLModel object with configured training options.
+    #' @param model An [MLModel] object with configured training options.
     #'
     #' @return Training response from the API containing request ID.
     train = function(model) {
@@ -103,8 +119,7 @@ MlTrainingService <- R6Class( # nolint: object_name_linter
 
     #' @description Save the selected model.
     #'
-    #' @param model The MLModel object to update and save. This should be an
-    #'   instance of MLModel.
+    #' @param model The [MLModel] object to update and save.
     #' @param best_models A list of best model results, typically from
     #'  MLTrainingResults$get_best_models().
     #'  Each item should contain model outcome, features, trainer name,

--- a/R/RepositoryService.R
+++ b/R/RepositoryService.R
@@ -7,6 +7,29 @@ library("R6")
 #' @details A new instance of this class will be created by the ServiceProvider
 #' automatically.
 #'
+#' @seealso
+#' Related classes:
+#' * [ServiceProvider] for creating a service provider instance
+#' * [DataServices] for loading and saving data using repository items
+#'
+#' Item classes that can be managed:
+#' * [Entity] for well, field, reservoir entities
+#' * [EntityType] for entity type definitions
+#' * [EntitySet] for entity collections
+#' * [Signal] for signal definitions
+#' * [Unit] and [UnitMeasurement] for unit definitions
+#' * [Hierarchy] for organizational structures
+#' * [Scope] for entity and signal selections
+#' * [Scenario] for data versions
+#' * [Tag] and [TagEntry] for metadata
+#' * [Workflow] for automated processes
+#' * [RScript] and [PSharpScript] for scripts
+#' * [MLModel] for machine learning models
+#'
+#' Vignettes:
+#' * `vignette("repository-service")` for comprehensive repository operations
+#' * `vignette("getting-started")` for basic usage
+#'
 #' @export RepositoryService
 #'
 #' @examples \dontrun{
@@ -20,12 +43,12 @@ library("R6")
 #' sp$items$delete("Hierarchy", "test")
 #'
 #' # get an item by name
-#' well01 <- sp$items$load("Well", "Well01")
+#' well01 <- sp$items$load("Entity", "Well01")
 #'
 #' # add or edit an item
 #' entity <- Entity$new(
 #'   name = "TestWell01",
-#'   entityTypeName = "Well",
+#'   entity_type_name = "Well",
 #'   alias = "TestAlias01"
 #' )
 #' sp$items$save("Entity", entity)
@@ -36,7 +59,7 @@ RepositoryService <- R6Class( # nolint: object_name_linter
   public = list(
 
     #' @description Create a new RepositoryService instance. This is done by the
-    #' ServiceProvider automatically.
+    #' [ServiceProvider] automatically.
     initialize = function() {},
 
     #' @description Get the names of all items of the given type available in

--- a/R/Scope.R
+++ b/R/Scope.R
@@ -21,6 +21,15 @@ library("R6")
 #' @field formula The scope's definition as string (P# syntax).
 #' @field description The description of the item.
 #' @field labels A list of strings holding the labels of the scope.
+#'
+#' @seealso
+#' * [RepositoryService] for managing scopes
+#' * [DataServices] for using scopes in data queries
+#' * [EntitySet] for entity filtering
+#' * [MLModel] for ML training context
+#' * `vignette("working-with-data")` for data examples
+#' * `vignette("machine-learning")` for ML examples
+#'
 #' @examples
 #' \dontrun{
 #' Scope$new(name = "MyScope",

--- a/R/ServiceProvider.R
+++ b/R/ServiceProvider.R
@@ -245,6 +245,17 @@ ServiceProvider <- R6Class( # nolint: object_name_linter
     #'   )
     #' }
     send_mail = function(address, subject, body) {
+      # Validate email address
+      if (is.null(address) || !is.character(address) || length(address) != 1) {
+        stop("Error: 'address' must be a single character string.")
+      }
+
+      # Check email format using regex
+      email_pattern <- "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+      if (!grepl(email_pattern, address, perl = TRUE)) {
+        stop("Error: '", address, "' is not a valid email address format.")
+      }
+
       query <- list(
         Address = address,
         Subject = subject,

--- a/R/ServiceProvider.R
+++ b/R/ServiceProvider.R
@@ -207,6 +207,34 @@ ServiceProvider <- R6Class( # nolint: object_name_linter
         stop(paste0("Error: Input must be a numeric value or a ",
                     "list/vector of numeric values (including NA)."))
       }
+    },
+
+    #' @description Send an email using the PetroVisor email configuration.
+    #'
+    #' @param address The recipient email address (single string).
+    #' @param subject The subject of the email.
+    #' @param body The body content of the email.
+    #'
+    #' @examples
+    #' \dontrun{
+    #'   # Send a simple email
+    #'   sp$send_mail(
+    #'     address = "example@domain.com",
+    #'     subject = "Test Subject",
+    #'     body = "This is a test email from PetroVisor R client."
+    #'   )
+    #' }
+    send_mail = function(address, subject, body) {
+      query <- list(
+        Address = address,
+        Subject = subject,
+        Body = body
+      )
+
+      super$get(url = paste0(self$data_url, "/"),
+                route = "Configuration/Send/Mail",
+                query = query,
+                parse_json = FALSE)
     }
   ),
   private = list(

--- a/R/ServiceProvider.R
+++ b/R/ServiceProvider.R
@@ -41,6 +41,26 @@ library("jsonlite")
 #' @field ml Instance of class \code{MlTrainingService} wrapping
 #'   all functionality related to ML model training and prediction.
 #'
+#' @seealso
+#' Service classes for interacting with PetroVisor:
+#' * [AuthenticationService] for authentication methods
+#' * [DataServices] for loading and saving data
+#' * [RepositoryService] for managing items (entities, signals, units, etc.)
+#' * [LoggingService] for logging operations
+#' * [FileService] for file operations
+#' * [MlTrainingService] for machine learning
+#' * [TagEntriesService] for tag entry operations
+#'
+#' Authentication helpers:
+#' * [get_auth_context()] for accessing the authentication context
+#' * [with_auth_context()] for executing code with specific auth context
+#' * [require_authentication()] for ensuring authentication
+#'
+#' Vignettes:
+#' * `vignette("getting-started")` for an introduction to the package
+#' * `vignette("authentication")` for authentication details
+#' * `vignette("working-with-data")` for data operations
+#'
 #' @examples
 #' \dontrun{
 #' # Create a new instance of the service provider using token

--- a/R/Signal.R
+++ b/R/Signal.R
@@ -9,7 +9,7 @@ library("R6")
 #' @field name The name of the signal.
 #' @field short_name The signal's short name.
 #' @field measurement_name The signal's measurement name.
-#' @field storage_unit_name The name of the signal's storage unit.
+#' @field storage_unit_name The name of the signal's storage [Unit].
 #' @field aggregation_type The signal's aggregation type.
 #' @field container_aggregation_type The signal's container aggregation type.
 #' @field signal_type The signal's type.
@@ -20,6 +20,13 @@ library("R6")
 #' @field labels A list of strings holding the labels of the signal.
 #' @field description The description of the signal.
 #'
+#' @seealso
+#' * [DataServices] for loading and saving signal data
+#' * [RepositoryService] for managing signal definitions
+#' * [Unit] for working with measurement units
+#' * [UnitMeasurement] for unit measurements
+#' * `vignette("working-with-data")` for data examples
+#'
 #' @examples
 #' \dontrun{
 #' Signal$new(name = "my signal",
@@ -28,14 +35,14 @@ library("R6")
 #'            storage_unit_name = "m",
 #'            aggregation_type = "Average",
 #'            container_aggregation_type = "Sum",
-#'            signal_type = "Time-dependent",
+#'            signal_type = "TimeDependent",
 #'            default_color = 0,
 #'            default_line_type = "Solid",
 #'            setting_name = NULL,
 #'            labels = list(),
 #'            description = NULL)
 #'}
-Signal <- R6Class("Signal",
+Signal <- R6Class("Signal", # nolint: object_name_linter
   public = list(
     name = NULL,
     short_name = NULL,

--- a/R/Tag.R
+++ b/R/Tag.R
@@ -9,11 +9,17 @@ library("R6")
 #' @field name The name of the tag.
 #' @field tag_group The tag's tag group.
 #'
+#' @seealso
+#' * [TagEntry] for tag entry definitions
+#' * [TagEntriesService] for managing tag entries
+#' * [RepositoryService] for loading and saving tags
+#' * [Entity] for entity definitions that can be tagged
+#'
 #' @examples
 #' \dontrun{
 #' Tag$new(name = "NewTag", tag_group = "Group 1")
 #'}
-Tag <- R6Class("Tag",
+Tag <- R6Class("Tag", # nolint: object_name_linter
   public = list(
     name = NULL,
     tag_group = NULL,

--- a/R/TagEntriesService.R
+++ b/R/TagEntriesService.R
@@ -8,6 +8,14 @@ library("R6")
 #' @details A new instance of this class will be created by the ServiceProvider
 #' automatically.
 #'
+#' @seealso
+#' * [ServiceProvider] for accessing the tag entries service via
+#' `sp$tag_entries`
+#' * [Tag] for tag definitions
+#' * [TagEntry] for tag entry structure
+#' * [RepositoryService] for managing tags
+#' * `vignette("getting-started")` for basic usage
+#'
 #' @export TagEntriesService
 #'
 #' @examples \dontrun{
@@ -15,14 +23,14 @@ library("R6")
 #' sp <- ServiceProvider$new("Host", 8095, "WorkspaceA", "UserX", "Password")
 #'
 #' # get tag entries of group "Info"
-#' tagEntries <- sp$tag_entries$GetTagEntries(
-#'   TagEntriesFilter$new(TagGroup = "Info")
+#' tagEntries <- sp$tag_entries$load(
+#'   tag_group_names = list("Info")
 #' )
 #'
 #' # delete tag entries
-#' sp$tag_entries$DeleteTagEntry(
-#'   entityName = "Well01",
-#'   tagName = "Active",
+#' sp$tag_entries$delete_range(
+#'   entity_name = "Well01",
+#'   tag_name = "Active",
 #'   start = "2020-01-01T00:00:00.000Z"
 #' )
 #' }
@@ -32,7 +40,7 @@ TagEntriesService <- R6Class( # nolint: object_name_linter
   public = list(
 
     #' @description Create a new TagEntriesService instance. This is done by the
-    #' ServiceProvider automatically.
+    #' [ServiceProvider] automatically.
     #'
     #' @param url the URL for the API calls.
     #' @param token_type the type of the issued token.

--- a/R/TagEntry.R
+++ b/R/TagEntry.R
@@ -6,10 +6,16 @@ library("R6")
 #'
 #' @export TagEntry
 #'
-#' @field tag_name The name of the tag.
-#' @field entity_name The name of the tagged entity.
+#' @field tag_name The name of the [Tag].
+#' @field entity_name The name of the tagged [Entity].
 #' @field start The start date of the tag entry.
 #' @field end The end date of the tag entry.
+#'
+#' @seealso
+#' * [Tag] for tag definitions
+#' * [TagEntriesService] for loading and saving tag entries
+#' * [Entity] for entity definitions
+#' * [RepositoryService] for repository operations
 #'
 #' @examples
 #' \dontrun{
@@ -21,7 +27,7 @@ library("R6")
 #'              tag_name = "Active",
 #'              start = "2020-02-01T00:00:00.000Z")
 #' }
-TagEntry <- R6Class("TagEntry",
+TagEntry <- R6Class("TagEntry", # nolint: object_name_linter
   public = list(
     tag_name = NULL,
     entity_name = NULL,
@@ -30,8 +36,8 @@ TagEntry <- R6Class("TagEntry",
 
     #' @description Create a new TagEntry instance.
     #'
-    #' @param tag_name The name of the tag.
-    #' @param entity_name The name of the tagged entity.
+    #' @param tag_name The name of the [Tag].
+    #' @param entity_name The name of the tagged [Entity].
     #' @param start The start date of the tag entry.
     #' @param end (Optional) The end date of the tag entry.
     initialize = function(tag_name = NULL,

--- a/R/Unit.R
+++ b/R/Unit.R
@@ -13,6 +13,12 @@ library("R6")
 #' @field summand The unit's summand. Used for conversion between the unit and
 #'   it's base (SI) unit.
 #'
+#' @seealso
+#' * [UnitMeasurement] for measurement definitions
+#' * [Signal] for signal definitions using units
+#' * [RepositoryService] for loading and saving units
+#' * [DataServices] for data operations with units
+#'
 #' @examples
 #' \dontrun{
 #' Unit$new(name = "hyper m",
@@ -20,7 +26,7 @@ library("R6")
 #'          factor = 10000000000000,
 #'          summand = 0)
 #'}
-Unit <- R6Class("Unit",
+Unit <- R6Class("Unit", # nolint: object_name_linter
   public = list(
     name = NULL,
     measurement_name = NULL,

--- a/R/UnitMeasurement.R
+++ b/R/UnitMeasurement.R
@@ -9,11 +9,16 @@ library("R6")
 #' @field name The name of the unit measurement.
 #' @field canonical_unit_name The name of the unit measurement's canonical unit.
 #'
+#' @seealso
+#' * [Unit] for unit definitions
+#' * [Signal] for signal definitions using measurements
+#' * [RepositoryService] for loading unit measurements
+#'
 #' @examples
 #' \dontrun{
 #' UnitMeasurement$new(name = "Length", canonical_unit_name = "m")
 #'}
-UnitMeasurement <- R6Class("UnitMeasurement",
+UnitMeasurement <- R6Class("UnitMeasurement", # nolint: object_name_linter
   public = list(
     name = NULL,
     canonical_unit_name = NULL,

--- a/R/Workflow.R
+++ b/R/Workflow.R
@@ -16,6 +16,15 @@ library("R6")
 #'   favorite item, and thus shown in the favorites tab on the home module in
 #'   PetroVisor. Defaults to \code{FALSE}.
 #' @field labels A list of strings holding the labels of the workflow.
+#'
+#' @seealso
+#' * [RepositoryService] for loading and saving workflows
+#' * [WorkflowActivity] for workflow activity definitions
+#' * [RWorkflowActivity] for R-based workflow activities
+#' * [CustomWorkflowActivity] for custom activities
+#' * [WorkflowSchedule] for scheduling workflows
+#' * `vignette("repository-service")` for workflow examples
+#'
 #' @examples
 #' \dontrun{
 #' Workflow$new()

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,3 +2,160 @@ url: https://datagration.github.io/petrovisor-r-api/
 template:
   bootstrap: 5
 
+reference:
+  - title: "Core Classes"
+    desc: "Main classes for interacting with PetroVisor API"
+    contents:
+      - ServiceProvider
+      - AuthenticationService
+  
+  - title: "Service Classes"
+    desc: "Specialized service classes"
+    contents:
+      - DataServices
+      - RepositoryService
+      - LoggingService
+      - FileService
+      - TagEntriesService
+      - MlTrainingService
+  
+  - title: "Data Types"
+    desc: "Classes representing different data types"
+    contents:
+      - StaticData
+      - TimeData
+      - DepthData
+      - PVTData
+      - ReferenceTable
+      - ReferenceTableColumn
+      - PivotTable
+      - DataPoint
+      - NamedPoint
+      - Point
+  
+  - title: "Entity & Signal Classes"
+    desc: "Classes for entities, signals, and related objects"
+    contents:
+      - Entity
+      - EntitySet
+      - EntityType
+      - Signal
+      - Unit
+      - UnitMeasurement
+      - Hierarchy
+      - Tag
+      - TagEntry
+      - CustomField
+  
+  - title: "Workflow & Script Classes"
+    desc: "Classes for workflows and scripts"
+    contents:
+      - Workflow
+      - WorkflowActivity
+      - WorkflowSchedule
+      - ScheduleRecurrence
+      - ScheduleEnd
+      - ProcessTemplate
+      - Step
+      - RScript
+      - PSharpScript
+      - RWorkflowActivity
+      - CustomWorkflowActivity
+      - ActivityArgument
+      - ActivityMappedArgument
+  
+  - title: "Machine Learning"
+    desc: "Machine learning related classes"
+    contents:
+      - MlTrainingService
+      - MLModel
+      - MLNetModel
+      - MLTrainingContext
+      - MLTrainingOptions
+      - MLCustomTrainingOptions
+      - MLNeuralNetworkTrainingOptions
+      - MLTransformerOptions
+      - MLTrainingFeature
+      - MLTrainingOutcome
+      - MLTrainingNumericOutcome
+      - MLTrainingResult
+      - MLTrainingResults
+      - MLPreProcessor
+      - MLDataProviderConfig
+      - RProviderConfiguration
+  
+  - title: "Calculation & Analysis"
+    desc: "Classes for calculations and analysis"
+    contents:
+      - CleansingCalculation
+      - EventCalculation
+      - TableCalculation
+      - DcaFit
+      - Chart
+      - Axis
+      - SeriesSetting
+  
+  - title: "Data Integration"
+    desc: "Classes for data connections and integration"
+    contents:
+      - DataConnection
+      - DataIntegrationSet
+      - DataMapping
+      - DataSource
+  
+  - title: "Supporting Classes"
+    desc: "Helper and configuration classes"
+    contents:
+      - ApiRequests
+      - AuthContext
+      - Context
+      - DataSetRequest
+      - Filter
+      - CleansingFilter
+      - CleansingScript
+      - Scope
+      - Scenario
+      - LogEntry
+      - Event
+      - Column
+      - ConfigurationSetting
+  
+  - title: "Authentication Helpers"
+    desc: "Helper functions for authentication"
+    contents:
+      - get_auth_context
+      - with_auth_context
+      - require_authentication
+
+articles:
+  - title: "Getting Started"
+    contents:
+      - getting-started
+  
+  - title: "Guides"
+    contents:
+      - authentication
+      - working-with-data
+      - repository-service
+      - machine-learning
+
+navbar:
+  structure:
+    left:  [intro, reference, articles, tutorials, news]
+    right: [search, github]
+  components:
+    articles:
+      text: Articles
+      menu:
+      - text: Getting Started
+        href: articles/getting-started.html
+      - text: -------
+      - text: Guides
+      - text: Authentication Guide
+        href: articles/authentication.html
+      - text: Working with Data
+        href: articles/working-with-data.html
+      - text: Repository Service
+        href: articles/repository-service.html
+      - text: Machine Learning
+        href: articles/machine-learning.html

--- a/man/AuthContext.Rd
+++ b/man/AuthContext.Rd
@@ -41,6 +41,17 @@ if (auth$is_authenticated()) {
 auth$clear_auth()
 }
 }
+\seealso{
+\itemize{
+\item \link{ServiceProvider} for creating authenticated sessions
+\item \link{AuthenticationService} for authentication methods
+\item \code{\link[=get_auth_context]{get_auth_context()}} for accessing the singleton instance
+\item \code{\link[=with_auth_context]{with_auth_context()}} for executing code with authentication
+\item \code{\link[=require_authentication]{require_authentication()}} for checking authentication status
+\item \code{vignette("authentication")} for authentication examples
+\item \code{vignette("getting-started")} for setup guide
+}
+}
 \section{Methods}{
 \subsection{Public methods}{
 \itemize{

--- a/man/AuthenticationService.Rd
+++ b/man/AuthenticationService.Rd
@@ -8,7 +8,8 @@ Provides methods for authenticating with the PetroVisor API.
 }
 \details{
 This class includes methods to obtain access tokens using various
-authentication mechanisms such as API keys, user credentials, and refresh tokens.
+authentication mechanisms such as API keys, user credentials, and refresh
+tokens.
 }
 \examples{
 \dontrun{
@@ -33,5 +34,25 @@ token <- auth_service$get_access_token(
   refresh_token = "your_refresh_token",
   discovery_url = "https://example.com"
 )
+}
+}
+\seealso{
+Related classes:
+\itemize{
+\item \link{ServiceProvider} for using tokens with the service provider
+\item \link{AuthContext} for managing authentication context
+}
+
+Authentication helpers:
+\itemize{
+\item \code{\link[=get_auth_context]{get_auth_context()}} for accessing the global authentication context
+\item \code{\link[=with_auth_context]{with_auth_context()}} for executing code with specific authentication
+\item \code{\link[=require_authentication]{require_authentication()}} for ensuring authentication is present
+}
+
+Vignettes:
+\itemize{
+\item \code{vignette("authentication")} for comprehensive authentication guide
+\item \code{vignette("getting-started")} for basic setup and usage
 }
 }

--- a/man/Context.Rd
+++ b/man/Context.Rd
@@ -22,17 +22,27 @@ Context$new(name = "MyContext",
                             time_increment = "Daily"))
 }
 }
+\seealso{
+\itemize{
+\item \link{Scope} for scope definitions
+\item \link{EntitySet} for entity set definitions
+\item \link{Hierarchy} for hierarchy definitions
+\item \link{RepositoryService} for loading and saving contexts
+\item \link{DataServices} for using contexts in data queries
+\item \code{vignette("working-with-data")} for data examples
+}
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
 \item{\code{name}}{The name of the context.}
 
-\item{\code{entity_set}}{The context's entity set (object of class EntitySet).}
+\item{\code{entity_set}}{The context's \link{EntitySet} defining which entities to
+include.}
 
-\item{\code{scope}}{The context's scope (object of class Scope).}
+\item{\code{scope}}{The context's \link{Scope} defining the time or depth range.}
 
-\item{\code{hierarchy}}{(Optional) The hierarchy used for automatic aggregation
-(Object of type Hierarchy).}
+\item{\code{hierarchy}}{(Optional) The \link{Hierarchy} used for automatic aggregation.}
 
 \item{\code{loading_scenario_name}}{(Optional) The name of the loading scenario.}
 
@@ -83,12 +93,13 @@ Create a new Context instance.
 \describe{
 \item{\code{name}}{The name of the context.}
 
-\item{\code{entity_set}}{The context's entity set (object of class EntitySet).}
+\item{\code{entity_set}}{The context's \link{EntitySet} defining which entities to
+include.}
 
-\item{\code{scope}}{The context's scope (object of class Scope).}
+\item{\code{scope}}{The context's \link{Scope} defining the time or depth range.}
 
-\item{\code{hierarchy}}{(Optional) The hierarchy used for automatic aggregation
-(Object of type Hierarchy).}
+\item{\code{hierarchy}}{(Optional) The \link{Hierarchy} used for automatic
+aggregation.}
 
 \item{\code{loading_scenario_name}}{(Optional) The name of the loading scenario.}
 
@@ -117,7 +128,7 @@ with workspace data.}
 
 \subsection{Details}{
 Convert the object to a list. This function is mainly used
-by the RepositoryService to convert the objects to lists and then
+by the \link{RepositoryService} to convert the objects to lists and then
 call the web API.
 }
 

--- a/man/DataServices.Rd
+++ b/man/DataServices.Rd
@@ -123,7 +123,7 @@ result <- sp$data$save(
   time_data <- sp$data$load(
     entities = c("Well_A"),
     signals = lapply(
-      c("oil production [bbl/d]", "gas production [mcf/d]"),
+      c("oil production [bbl/d]", "gas production [MSCF/d]"),
       function(x) { sp$parse_signal(x) }
     ),
     time_increment = "Daily",
@@ -212,7 +212,7 @@ result <- sp$data$save(
     data_type = "StaticNumeric",
     data = static_numeric_data,
     signals = lapply(
-      c("initial oil reserves [bbl]", "initial gas reserves [mcf]"),
+      c("initial oil reserves [bbl]", "initial gas reserves [MSCF]"),
       function(x) { sp$parse_signal(x) }
     ),
     generate_logs = TRUE,
@@ -251,7 +251,7 @@ result <- sp$data$save(
     data_type = "TimeNumeric",
     data = time_numeric_data,
     signals = lapply(
-      c("oil rate [bbl/d]", "gas rate [mcf/d]"),
+      c("oil rate [bbl/d]", "gas rate [MSCF/d]"),
       function(x) { sp$parse_signal(x) }
     ),
     values_time_increment = "Daily"
@@ -446,6 +446,36 @@ result <- sp$data$save(
   )
 }
 }
+\seealso{
+Related classes:
+\itemize{
+\item \link{ServiceProvider} for creating a service provider instance
+\item \link{RepositoryService} for managing entities and signals
+}
+
+Data type classes:
+\itemize{
+\item \link{StaticData} for static data structure
+\item \link{TimeData} for time series data structure
+\item \link{DepthData} for depth data structure
+\item \link{PVTData} for PVT data structure
+\item \link{ReferenceTable} for reference table structure
+\item \link{PivotTable} for pivot table structure
+}
+
+Related objects:
+\itemize{
+\item \link{Signal} for signal definitions
+\item \link{Entity} for entity definitions
+\item \link{Unit} for unit definitions
+}
+
+Vignettes:
+\itemize{
+\item \code{vignette("working-with-data")} for comprehensive data operations guide
+\item \code{vignette("getting-started")} for basic usage
+}
+}
 \concept{data deletion functions}
 \concept{data loading functions}
 \concept{data saving functions}
@@ -473,7 +503,7 @@ result <- sp$data$save(
 \if{latex}{\out{\hypertarget{method-DataServices-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new DataServices instance. This is done by the
-ServiceProvider automatically.
+\link{ServiceProvider} automatically.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{DataServices$new(sp)}\if{html}{\out{</div>}}
 }
@@ -481,7 +511,7 @@ ServiceProvider automatically.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{sp}}{instance of the service provider}
+\item{\code{sp}}{Instance of the \link{ServiceProvider}}
 }
 \if{html}{\out{</div>}}
 }
@@ -522,15 +552,15 @@ Load signal data from PetroVisor.
 \item{\code{entities}}{List of entities to retrieve data for. Can be:
 \itemize{
 \item Character vector: \code{c("Well_001", "Well_002")}
-\item List of Entity objects: \code{list(entity1, entity2)}
+\item List of \link{Entity} objects: \code{list(entity1, entity2)}
 }}
 
-\item{\code{signals}}{List of parsed signal objects created using
+\item{\code{signals}}{List of parsed \link{Signal} objects created using
 \code{sp$parse_signal()}. Each signal should specify name and unit.}
 
 \item{\code{scenario_names}}{List of scenario names to load data for.}
 
-\item{\code{hierarchy_name}}{Hierarchy used in the data retrieval process.}
+\item{\code{hierarchy_name}}{\link{Hierarchy} used in the data retrieval process.}
 
 \item{\code{top_records}}{Number of records to return.}
 
@@ -612,7 +642,7 @@ or raw API response when reshape = FALSE.
   time_data <- sp$data$load(
     entities = c("Well_A"),
     signals = lapply(
-      c("oil production [bbl/d]", "gas production [mcf/d]"),
+      c("oil production [bbl/d]", "gas production [MSCF/d]"),
       function(x) { sp$parse_signal(x) }
     ),
     time_increment = "Daily",
@@ -836,7 +866,7 @@ the save operation.
     data_type = "StaticNumeric",
     data = static_numeric_data,
     signals = lapply(
-      c("initial oil reserves [bbl]", "initial gas reserves [mcf]"),
+      c("initial oil reserves [bbl]", "initial gas reserves [MSCF]"),
       function(x) { sp$parse_signal(x) }
     ),
     generate_logs = TRUE,
@@ -875,7 +905,7 @@ the save operation.
     data_type = "TimeNumeric",
     data = time_numeric_data,
     signals = lapply(
-      c("oil rate [bbl/d]", "gas rate [mcf/d]"),
+      c("oil rate [bbl/d]", "gas rate [MSCF/d]"),
       function(x) { sp$parse_signal(x) }
     ),
     values_time_increment = "Daily"

--- a/man/DataSetRequest.Rd
+++ b/man/DataSetRequest.Rd
@@ -4,23 +4,42 @@
 \alias{DataSetRequest}
 \title{DataSetRequest}
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
 Class representing a PetroVisor dataset request object.
+
+\strong{This class is deprecated and no longer used.} It was originally designed
+for use with DataServices but was never integrated into the actual
+implementation. DataServices uses direct parameter passing instead.
+
+This class is retained only for backwards compatibility and may be removed
+in a future version.
 }
 \examples{
 \dontrun{
+# DEPRECATED: This class is not used by DataServices
 DataSetRequest$new(entityName = "Well01",
                    signalName = "surface x-coordinate",
                    unitName = "m")
 }
 }
+\seealso{
+\itemize{
+\item \link{DataServices} for loading data (does not use DataSetRequest)
+\item \link{Entity} for entity definitions
+\item \link{Signal} for signal definitions
+\item \link{Unit} for unit definitions
+\item \code{vignette("working-with-data")} for data loading examples
+}
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
-\item{\code{entityName}}{The name of the entity for which data is requested.}
+\item{\code{entityName}}{The name of the \link{Entity} for which data is requested.}
 
-\item{\code{signalName}}{The name of the requested signal.}
+\item{\code{signalName}}{The name of the requested \link{Signal}.}
 
-\item{\code{unitName}}{The name of the unit the data is requested in.}
+\item{\code{unitName}}{The name of the \link{Unit} the data is requested in.}
 }
 \if{html}{\out{</div>}}
 }
@@ -36,7 +55,12 @@ DataSetRequest$new(entityName = "Well01",
 \if{html}{\out{<a id="method-DataSetRequest-new"></a>}}
 \if{latex}{\out{\hypertarget{method-DataSetRequest-new}{}}}
 \subsection{Method \code{new()}}{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
 Create a new DataSetRequest instance.
+
+\strong{Deprecated:} This class is not used by DataServices and will be
+removed in a future version.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{DataSetRequest$new(entityName = NULL, signalName = NULL, unitName = NULL)}\if{html}{\out{</div>}}
 }
@@ -44,11 +68,11 @@ Create a new DataSetRequest instance.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{entityName}}{The name of the entity for which data is requested.}
+\item{\code{entityName}}{The name of the \link{Entity} for which data is requested.}
 
-\item{\code{signalName}}{The name of the requested signal.}
+\item{\code{signalName}}{The name of the requested \link{Signal}.}
 
-\item{\code{unitName}}{The name of the unit the data is requested in.}
+\item{\code{unitName}}{The name of the \link{Unit} the data is requested in.}
 }
 \if{html}{\out{</div>}}
 }
@@ -57,9 +81,13 @@ Create a new DataSetRequest instance.
 \if{html}{\out{<a id="method-DataSetRequest-toList"></a>}}
 \if{latex}{\out{\hypertarget{method-DataSetRequest-toList}{}}}
 \subsection{Method \code{toList()}}{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
 Convert the object to a list. This function is mainly used
-by the DataServices to convert the objects to lists and then
+by \link{DataServices} to convert the objects to lists and then
 call the web API.
+
+\strong{Deprecated:} This method is not used by DataServices.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{DataSetRequest$toList()}\if{html}{\out{</div>}}
 }

--- a/man/DepthData.Rd
+++ b/man/DepthData.Rd
@@ -8,7 +8,7 @@ Class representing depth-dependent data.
 }
 \examples{
 \dontrun{
-TimeData$new(singal_name = "produced oil per depth increment",
+TimeData$new(signal_name = "produced oil per depth increment",
              entity_name = "Well01",
              unit_name = "m3",
              data = list(list(Depth = 100,

--- a/man/Entity.Rd
+++ b/man/Entity.Rd
@@ -15,6 +15,15 @@ Entity$new(
   is_opportunity = FALSE)
 }
 }
+\seealso{
+\itemize{
+\item \link{RepositoryService} for loading and saving entities
+\item \link{EntitySet} for grouping entities
+\item \link{EntityType} for entity type definitions
+\item \link{DataServices} for working with entity data
+\item \code{vignette("repository-service")} for repository examples
+}
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
@@ -74,7 +83,7 @@ Create a new Entity instance.
 
 \subsection{Details}{
 Convert the object to a list. This function is mainly used
-by the RepositoryService to convert the objects to lists and then
+by the \link{RepositoryService} to convert the objects to lists and then
 call the web API.
 }
 

--- a/man/EntitySet.Rd
+++ b/man/EntitySet.Rd
@@ -17,12 +17,21 @@ EntitySet$new(name = "MyEntities",
                                       alias = "WellAlias2")))
 }
 }
+\seealso{
+\itemize{
+\item \link{Entity} for entity definitions
+\item \link{RepositoryService} for managing entity sets
+\item \link{Scope} for time/depth filtering
+\item \link{MLModel} for ML training context
+\item \code{vignette("repository-service")} for examples
+}
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
 \item{\code{name}}{The name of the entity set.}
 
-\item{\code{entities}}{list of entity objects.}
+\item{\code{entities}}{List of \link{Entity} objects.}
 
 \item{\code{formula}}{The entity set's definition as string (P# syntax).}
 
@@ -60,7 +69,7 @@ Create a new EntitySet instance.
 \describe{
 \item{\code{name}}{The name of the entity set.}
 
-\item{\code{entities}}{list of entity objects.}
+\item{\code{entities}}{List of \link{Entity} objects.}
 
 \item{\code{formula}}{The entity set's definition as string (P# syntax).}
 
@@ -81,7 +90,7 @@ Create a new EntitySet instance.
 
 \subsection{Details}{
 Convert the object to a list. This function is mainly used
-by the RepositoryService to convert the objects to lists and then
+by the \link{RepositoryService} to convert the objects to lists and then
 call the web API.
 }
 

--- a/man/EntityType.Rd
+++ b/man/EntityType.Rd
@@ -11,6 +11,13 @@ Class representing a PetroVisor entityType object.
 EntityType$new(name = "Section")
 }
 }
+\seealso{
+\itemize{
+\item \link{Entity} for entity definitions
+\item \link{RepositoryService} for loading entity types
+\item \code{vignette("repository-service")} for examples
+}
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{

--- a/man/FileService.Rd
+++ b/man/FileService.Rd
@@ -34,6 +34,12 @@ file <- sp$files$load("Test_File.csv")
 result <- sp$files$save("Test_File.csv")
 }
 }
+\seealso{
+\itemize{
+\item \link{ServiceProvider} for accessing the file service via \code{sp$files}
+\item \code{vignette("getting-started")} for basic usage
+}
+}
 \section{Super class}{
 \code{\link[Myrconn.PetroVisor.Client:ApiRequests]{Myrconn.PetroVisor.Client::ApiRequests}} -> \code{FileService}
 }
@@ -53,7 +59,7 @@ result <- sp$files$save("Test_File.csv")
 \if{latex}{\out{\hypertarget{method-FileService-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new FileService instance. This is done by the
-ServiceProvider automatically.
+\link{ServiceProvider} automatically.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{FileService$new()}\if{html}{\out{</div>}}
 }

--- a/man/Hierarchy.Rd
+++ b/man/Hierarchy.Rd
@@ -14,6 +14,14 @@ Hierarchy$new(name = "MyHierarchy",
                                   Parent1 = NA))
 }
 }
+\seealso{
+\itemize{
+\item \link{RepositoryService} for loading and saving hierarchies
+\item \link{Context} for using hierarchies in data contexts
+\item \link{Entity} for entity definitions
+\item \code{vignette("repository-service")} for hierarchy examples
+}
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{

--- a/man/LogEntry.Rd
+++ b/man/LogEntry.Rd
@@ -14,6 +14,13 @@ LogEntry$new(category = "MyCategory",
              severity = "Debug")
 }
 }
+\seealso{
+\itemize{
+\item \link{LoggingService} for saving and loading log entries
+\item \link{ServiceProvider} for accessing the logging service
+\item \code{vignette("getting-started")} for logging examples
+}
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{

--- a/man/LoggingService.Rd
+++ b/man/LoggingService.Rd
@@ -17,18 +17,18 @@ automatically.
 sp <- ServiceProvider$new("Host", 8095, "WorkspaceA", "UserX", "Password")
 
 # get available categories
-availableCategories <- sp$logs$GetAvailableCategories()
+availableCategories <- sp$logs$load_categories()
 
 # get log entries
-allLogEntries <- sp$logs$GetLogEntries()
-warnings <- sp$logs$GetLogEntries(severity = "Warning")
-signIns <- sp$logs$GetLogEntries(category = "SignIn")
+allLogEntries <- sp$logs$load()
+warnings <- sp$logs$load(severities = "Warning")
+signIns <- sp$logs$load(categories = "SignIn")
 
 # add log entry
 entry <- LogEntry$new(message = "Test",
                       category = "Tag",
                       severity = "Information")
-sp$logs$AddLogEntry(entry)
+sp$logs$save(list(entry))
 
 # add several log entries at once
 entry1 <- LogEntry$new(message = "Test1",
@@ -37,10 +37,17 @@ entry1 <- LogEntry$new(message = "Test1",
 entry2 <- LogEntry$new(message = "Test2",
                        category = "Tag",
                        severity = "Information")
-sp$logs$AddLogEntries(list(entry1, entry2))
+sp$logs$save(list(entry1, entry2))
 
 # remove all log entries
-sp$logs$CleanUpLogEntries()
+sp$logs$delete(days_to_keep = 0)
+}
+}
+\seealso{
+\itemize{
+\item \link{ServiceProvider} for accessing the logging service via \code{sp$logs}
+\item \link{LogEntry} for log entry structure
+\item \code{vignette("getting-started")} for basic usage
 }
 }
 \section{Super class}{
@@ -62,7 +69,7 @@ sp$logs$CleanUpLogEntries()
 \if{latex}{\out{\hypertarget{method-LoggingService-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new LoggingService instance. This is done by
-the ServiceProvider automatically.
+the \link{ServiceProvider} automatically.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{LoggingService$new()}\if{html}{\out{</div>}}
 }

--- a/man/MLModel.Rd
+++ b/man/MLModel.Rd
@@ -90,6 +90,18 @@ model$set_custom_training(
 )
 }
 }
+\seealso{
+\itemize{
+\item \link{MlTrainingService} for training and managing ML models
+\item \link{MLTrainingResult} for training results
+\item \link{MLTrainingResults} for multiple training results
+\item \link{MLTrainingOptions} for training configuration
+\item \link{MLPreProcessor} for preprocessing methods
+\item \link{Scope} for defining training context
+\item \link{EntitySet} for entity filtering
+\item \code{vignette("machine-learning")} for ML workflow examples
+}
+}
 \section{Super class}{
 \code{\link[Myrconn.PetroVisor.Client:ApiRequests]{Myrconn.PetroVisor.Client::ApiRequests}} -> \code{MLModel}
 }

--- a/man/MlTrainingService.Rd
+++ b/man/MlTrainingService.Rd
@@ -45,6 +45,26 @@ sp$ml$save_best_model(model, best_models, request$id)
 predictions <- sp$ml$predict(model$name, predictor_values)
 }
 }
+\seealso{
+Related classes:
+\itemize{
+\item \link{ServiceProvider} for accessing the ML service via \code{sp$ml}
+\item \link{MLModel} for model configuration
+\item \link{MLTrainingOptions} for training configuration
+\item \link{MLTrainingContext} for training context definitions
+\item \link{MLTrainingFeature} for feature definitions
+\item \link{MLTrainingOutcome} for outcome metric definitions
+\item \link{MLTrainingResult} and \link{MLTrainingResults} for training results
+\item \link{DataServices} for loading training data
+\item \link{RepositoryService} for managing ML models
+}
+
+Vignettes:
+\itemize{
+\item \code{vignette("machine-learning")} for comprehensive ML guide
+\item \code{vignette("getting-started")} for basic usage
+}
+}
 \section{Super class}{
 \code{\link[Myrconn.PetroVisor.Client:ApiRequests]{Myrconn.PetroVisor.Client::ApiRequests}} -> \code{MlTrainingService}
 }
@@ -65,8 +85,8 @@ predictions <- sp$ml$predict(model$name, predictor_values)
 \if{latex}{\out{\hypertarget{method-MlTrainingService-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new MlTrainingService instance. This is done by
-the ServiceProvider automatically. The service uses the singleton
-AuthContext for authentication.
+the \link{ServiceProvider} automatically. The service uses the singleton
+\link{AuthContext} for authentication.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{MlTrainingService$new()}\if{html}{\out{</div>}}
 }
@@ -84,7 +104,7 @@ Train machine learning models.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{model}}{An MLModel object with configured training options.}
+\item{\code{model}}{An \link{MLModel} object with configured training options.}
 }
 \if{html}{\out{</div>}}
 }
@@ -144,8 +164,7 @@ Save the selected model.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{model}}{The MLModel object to update and save. This should be an
-instance of MLModel.}
+\item{\code{model}}{The \link{MLModel} object to update and save.}
 
 \item{\code{best_models}}{A list of best model results, typically from
 MLTrainingResults$get_best_models().

--- a/man/PVTData.Rd
+++ b/man/PVTData.Rd
@@ -8,7 +8,7 @@ Class representing pvt data.
 }
 \examples{
 \dontrun{
-PVTData$new(singal_name = "produced oil per time increment pvt",
+PVTData$new(signal_name = "produced oil per time increment pvt",
             entity_name = "Well01",
             unit_name = "m3",
             data = list(list(Pressure = 300,

--- a/man/RepositoryService.Rd
+++ b/man/RepositoryService.Rd
@@ -22,15 +22,44 @@ entityNames <- sp$items$load_names("Entity")
 sp$items$delete("Hierarchy", "test")
 
 # get an item by name
-well01 <- sp$items$load("Well", "Well01")
+well01 <- sp$items$load("Entity", "Well01")
 
 # add or edit an item
 entity <- Entity$new(
   name = "TestWell01",
-  entityTypeName = "Well",
+  entity_type_name = "Well",
   alias = "TestAlias01"
 )
 sp$items$save("Entity", entity)
+}
+}
+\seealso{
+Related classes:
+\itemize{
+\item \link{ServiceProvider} for creating a service provider instance
+\item \link{DataServices} for loading and saving data using repository items
+}
+
+Item classes that can be managed:
+\itemize{
+\item \link{Entity} for well, field, reservoir entities
+\item \link{EntityType} for entity type definitions
+\item \link{EntitySet} for entity collections
+\item \link{Signal} for signal definitions
+\item \link{Unit} and \link{UnitMeasurement} for unit definitions
+\item \link{Hierarchy} for organizational structures
+\item \link{Scope} for entity and signal selections
+\item \link{Scenario} for data versions
+\item \link{Tag} and \link{TagEntry} for metadata
+\item \link{Workflow} for automated processes
+\item \link{RScript} and \link{PSharpScript} for scripts
+\item \link{MLModel} for machine learning models
+}
+
+Vignettes:
+\itemize{
+\item \code{vignette("repository-service")} for comprehensive repository operations
+\item \code{vignette("getting-started")} for basic usage
 }
 }
 \section{Super class}{
@@ -52,7 +81,7 @@ sp$items$save("Entity", entity)
 \if{latex}{\out{\hypertarget{method-RepositoryService-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new RepositoryService instance. This is done by the
-ServiceProvider automatically.
+\link{ServiceProvider} automatically.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{RepositoryService$new()}\if{html}{\out{</div>}}
 }

--- a/man/Scope.Rd
+++ b/man/Scope.Rd
@@ -14,6 +14,16 @@ Scope$new(name = "MyScope",
           time_increment = "Daily")
 }
 }
+\seealso{
+\itemize{
+\item \link{RepositoryService} for managing scopes
+\item \link{DataServices} for using scopes in data queries
+\item \link{EntitySet} for entity filtering
+\item \link{MLModel} for ML training context
+\item \code{vignette("working-with-data")} for data examples
+\item \code{vignette("machine-learning")} for ML examples
+}
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{

--- a/man/ServiceProvider.Rd
+++ b/man/ServiceProvider.Rd
@@ -30,6 +30,19 @@ sp <- ServiceProvider$new(
   password = "your_password"
 )
 }
+
+## ------------------------------------------------
+## Method `ServiceProvider$send_mail`
+## ------------------------------------------------
+
+\dontrun{
+  # Send a simple email
+  sp$send_mail(
+    address = "example@domain.com",
+    subject = "Test Subject",
+    body = "This is a test email from PetroVisor R client."
+  )
+}
 }
 \section{Super class}{
 \code{\link[Myrconn.PetroVisor.Client:ApiRequests]{Myrconn.PetroVisor.Client::ApiRequests}} -> \code{ServiceProvider}
@@ -78,6 +91,7 @@ all functionality related to ML model training and prediction.}
 \item \href{#method-ServiceProvider-set_workspace_data_url}{\code{ServiceProvider$set_workspace_data_url()}}
 \item \href{#method-ServiceProvider-getDataUrl}{\code{ServiceProvider$getDataUrl()}}
 \item \href{#method-ServiceProvider-convert_unit}{\code{ServiceProvider$convert_unit()}}
+\item \href{#method-ServiceProvider-send_mail}{\code{ServiceProvider$send_mail()}}
 \item \href{#method-ServiceProvider-clone}{\code{ServiceProvider$clone()}}
 }
 }
@@ -181,6 +195,42 @@ values.}
 }
 \if{html}{\out{</div>}}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ServiceProvider-send_mail"></a>}}
+\if{latex}{\out{\hypertarget{method-ServiceProvider-send_mail}{}}}
+\subsection{Method \code{send_mail()}}{
+Send an email using the PetroVisor email configuration.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{ServiceProvider$send_mail(address, subject, body)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{address}}{The recipient email address (single string).}
+
+\item{\code{subject}}{The subject of the email.}
+
+\item{\code{body}}{The body content of the email.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{\dontrun{
+  # Send a simple email
+  sp$send_mail(
+    address = "example@domain.com",
+    subject = "Test Subject",
+    body = "This is a test email from PetroVisor R client."
+  )
+}
+}
+\if{html}{\out{</div>}}
+
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-ServiceProvider-clone"></a>}}

--- a/man/ServiceProvider.Rd
+++ b/man/ServiceProvider.Rd
@@ -44,6 +44,32 @@ sp <- ServiceProvider$new(
   )
 }
 }
+\seealso{
+Service classes for interacting with PetroVisor:
+\itemize{
+\item \link{AuthenticationService} for authentication methods
+\item \link{DataServices} for loading and saving data
+\item \link{RepositoryService} for managing items (entities, signals, units, etc.)
+\item \link{LoggingService} for logging operations
+\item \link{FileService} for file operations
+\item \link{MlTrainingService} for machine learning
+\item \link{TagEntriesService} for tag entry operations
+}
+
+Authentication helpers:
+\itemize{
+\item \code{\link[=get_auth_context]{get_auth_context()}} for accessing the authentication context
+\item \code{\link[=with_auth_context]{with_auth_context()}} for executing code with specific auth context
+\item \code{\link[=require_authentication]{require_authentication()}} for ensuring authentication
+}
+
+Vignettes:
+\itemize{
+\item \code{vignette("getting-started")} for an introduction to the package
+\item \code{vignette("authentication")} for authentication details
+\item \code{vignette("working-with-data")} for data operations
+}
+}
 \section{Super class}{
 \code{\link[Myrconn.PetroVisor.Client:ApiRequests]{Myrconn.PetroVisor.Client::ApiRequests}} -> \code{ServiceProvider}
 }

--- a/man/Signal.Rd
+++ b/man/Signal.Rd
@@ -14,12 +14,21 @@ Signal$new(name = "my signal",
            storage_unit_name = "m",
            aggregation_type = "Average",
            container_aggregation_type = "Sum",
-           signal_type = "Time-dependent",
+           signal_type = "TimeDependent",
            default_color = 0,
            default_line_type = "Solid",
            setting_name = NULL,
            labels = list(),
            description = NULL)
+}
+}
+\seealso{
+\itemize{
+\item \link{DataServices} for loading and saving signal data
+\item \link{RepositoryService} for managing signal definitions
+\item \link{Unit} for working with measurement units
+\item \link{UnitMeasurement} for unit measurements
+\item \code{vignette("working-with-data")} for data examples
 }
 }
 \section{Public fields}{
@@ -31,7 +40,7 @@ Signal$new(name = "my signal",
 
 \item{\code{measurement_name}}{The signal's measurement name.}
 
-\item{\code{storage_unit_name}}{The name of the signal's storage unit.}
+\item{\code{storage_unit_name}}{The name of the signal's storage \link{Unit}.}
 
 \item{\code{aggregation_type}}{The signal's aggregation type.}
 

--- a/man/Tag.Rd
+++ b/man/Tag.Rd
@@ -11,6 +11,14 @@ Class representing a PetroVisor tag object.
 Tag$new(name = "NewTag", tag_group = "Group 1")
 }
 }
+\seealso{
+\itemize{
+\item \link{TagEntry} for tag entry definitions
+\item \link{TagEntriesService} for managing tag entries
+\item \link{RepositoryService} for loading and saving tags
+\item \link{Entity} for entity definitions that can be tagged
+}
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{

--- a/man/TagEntriesService.Rd
+++ b/man/TagEntriesService.Rd
@@ -17,14 +17,14 @@ automatically.
 sp <- ServiceProvider$new("Host", 8095, "WorkspaceA", "UserX", "Password")
 
 # get tag entries of group "Info"
-tagEntries <- sp$tag_entries$GetTagEntries(
-  TagEntriesFilter$new(TagGroup = "Info")
+tagEntries <- sp$tag_entries$load(
+  tag_group_names = list("Info")
 )
 
 # delete tag entries
-sp$tag_entries$DeleteTagEntry(
-  entityName = "Well01",
-  tagName = "Active",
+sp$tag_entries$delete_range(
+  entity_name = "Well01",
+  tag_name = "Active",
   start = "2020-01-01T00:00:00.000Z"
 )
 }
@@ -35,6 +35,16 @@ sp$tag_entries$DeleteTagEntry(
 
 \dontrun{
 tagEntries <- sp$tag_entries$load(tag_group_names = c("Info"))
+}
+}
+\seealso{
+\itemize{
+\item \link{ServiceProvider} for accessing the tag entries service via
+\code{sp$tag_entries}
+\item \link{Tag} for tag definitions
+\item \link{TagEntry} for tag entry structure
+\item \link{RepositoryService} for managing tags
+\item \code{vignette("getting-started")} for basic usage
 }
 }
 \section{Super class}{
@@ -56,7 +66,7 @@ tagEntries <- sp$tag_entries$load(tag_group_names = c("Info"))
 \if{latex}{\out{\hypertarget{method-TagEntriesService-new}{}}}
 \subsection{Method \code{new()}}{
 Create a new TagEntriesService instance. This is done by the
-ServiceProvider automatically.
+\link{ServiceProvider} automatically.
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{TagEntriesService$new()}\if{html}{\out{</div>}}
 }

--- a/man/TagEntry.Rd
+++ b/man/TagEntry.Rd
@@ -17,12 +17,20 @@ TagEntry$new(entity_name = "Well 01" ,
              start = "2020-02-01T00:00:00.000Z")
 }
 }
+\seealso{
+\itemize{
+\item \link{Tag} for tag definitions
+\item \link{TagEntriesService} for loading and saving tag entries
+\item \link{Entity} for entity definitions
+\item \link{RepositoryService} for repository operations
+}
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
-\item{\code{tag_name}}{The name of the tag.}
+\item{\code{tag_name}}{The name of the \link{Tag}.}
 
-\item{\code{entity_name}}{The name of the tagged entity.}
+\item{\code{entity_name}}{The name of the tagged \link{Entity}.}
 
 \item{\code{start}}{The start date of the tag entry.}
 
@@ -50,9 +58,9 @@ Create a new TagEntry instance.
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{tag_name}}{The name of the tag.}
+\item{\code{tag_name}}{The name of the \link{Tag}.}
 
-\item{\code{entity_name}}{The name of the tagged entity.}
+\item{\code{entity_name}}{The name of the tagged \link{Entity}.}
 
 \item{\code{start}}{The start date of the tag entry.}
 

--- a/man/TimeData.Rd
+++ b/man/TimeData.Rd
@@ -8,7 +8,7 @@ Class representing time-dependent data.
 }
 \examples{
 \dontrun{
-TimeData$new(singal_name = "produced oil per time increment",
+TimeData$new(signal_name = "produced oil per time increment",
              entity_name = "Well01",
              unit_name = "m3",
              data = list(list(Date = "2020-01-01T00:00:00.000Z",

--- a/man/Unit.Rd
+++ b/man/Unit.Rd
@@ -14,6 +14,14 @@ Unit$new(name = "hyper m",
          summand = 0)
 }
 }
+\seealso{
+\itemize{
+\item \link{UnitMeasurement} for measurement definitions
+\item \link{Signal} for signal definitions using units
+\item \link{RepositoryService} for loading and saving units
+\item \link{DataServices} for data operations with units
+}
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{

--- a/man/UnitMeasurement.Rd
+++ b/man/UnitMeasurement.Rd
@@ -11,6 +11,13 @@ Class representing a PetroVisor unit measurement object.
 UnitMeasurement$new(name = "Length", canonical_unit_name = "m")
 }
 }
+\seealso{
+\itemize{
+\item \link{Unit} for unit definitions
+\item \link{Signal} for signal definitions using measurements
+\item \link{RepositoryService} for loading unit measurements
+}
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{

--- a/man/Workflow.Rd
+++ b/man/Workflow.Rd
@@ -11,6 +11,16 @@ Class representing a PetroVisor workflow object.
 Workflow$new()
 }
 }
+\seealso{
+\itemize{
+\item \link{RepositoryService} for loading and saving workflows
+\item \link{WorkflowActivity} for workflow activity definitions
+\item \link{RWorkflowActivity} for R-based workflow activities
+\item \link{CustomWorkflowActivity} for custom activities
+\item \link{WorkflowSchedule} for scheduling workflows
+\item \code{vignette("repository-service")} for workflow examples
+}
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{

--- a/tests/testthat/test_dataSetRequest.R
+++ b/tests/testthat/test_dataSetRequest.R
@@ -1,12 +1,17 @@
 ##### DATA SET REQUEST #####
+# NOTE: DataSetRequest is deprecated as of v3.6.0
+# These tests are retained for backward compatibility verification only
+
 context("Data set request instantiation and conversion to list")
 
-test_that("Data set request instantiation and conversion works",{
-  dsr <- DataSetRequest$new(entityName = "Well01",
-                            signalName = "oil rate",
-                            unitName = "m3/d")
-
-  listed <- dsr$toList()
+test_that("Data set request instantiation and conversion works", {
+  # Suppress deprecation warnings for testing deprecated functionality
+  suppressWarnings({
+    dsr <- DataSetRequest$new(entityName = "Well01",
+                              signalName = "oil rate",
+                              unitName = "m3/d")
+    listed <- dsr$toList()
+  })
 
   expect_equal(listed,
                list(Entity = "Well01",
@@ -15,10 +20,12 @@ test_that("Data set request instantiation and conversion works",{
 })
 
 test_that("Data set request instantiation and conversion works
-          (empty constructor)",{
-  dsr <- DataSetRequest$new()
-
-  listed <- dsr$toList()
+          (empty constructor)", {
+  # Suppress deprecation warnings for testing deprecated functionality
+  suppressWarnings({
+    dsr <- DataSetRequest$new()
+    listed <- dsr$toList()
+  })
 
   expect_equal(listed,
                list(Entity = "",

--- a/vignettes/authentication.Rmd
+++ b/vignettes/authentication.Rmd
@@ -1,0 +1,471 @@
+---
+title: "Authentication Guide"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Authentication Guide}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  eval = FALSE
+)
+```
+
+```{r setup}
+library(Myrconn.PetroVisor.Client)
+```
+
+# Overview
+
+Authentication is the first step in using the `Myrconn.PetroVisor.Client` package. This guide covers all authentication methods, managing authentication contexts, and best practices for secure API access.
+
+# Authentication Service
+
+The `AuthenticationService` class handles all authentication operations. It provides methods to obtain access tokens using various authentication mechanisms.
+
+## Creating an Authentication Service Instance
+
+```{r auth-service}
+auth_service <- AuthenticationService$new()
+```
+
+# Authentication Methods
+
+The package supports three primary authentication methods:
+
+## 1. API Key Authentication
+
+API keys are the recommended method for programmatic access. They are base64-encoded credentials that can be generated from the PetroVisor web interface.
+
+```{r api-key}
+# Authenticate using an API key
+token_response <- auth_service$get_access_token(
+  key = "your_api_key_here",
+  discovery_url = "https://identity.us1.petrovisor.com"
+)
+
+# The response contains:
+# - access_token: The token to use for API requests
+# - token_type: Usually "Bearer"
+# - expires_in: Token lifetime in seconds
+# - refresh_token: Token for refreshing access
+
+access_token <- token_response$access_token
+refresh_token <- token_response$refresh_token
+```
+
+### How API Keys Work
+
+API keys are base64-encoded strings containing username and password information. The `AuthenticationService` automatically:
+
+1. Decodes the API key
+2. Extracts the credentials
+3. Obtains an access token from the identity server
+4. Returns the token response
+
+## 2. Username and Password Authentication
+
+If you don't have an API key, you can authenticate directly with credentials:
+
+```{r username-password}
+token_response <- auth_service$get_access_token(
+  username = "your_username",
+  password = "your_password",
+  discovery_url = "https://identity.us1.petrovisor.com"
+)
+
+access_token <- token_response$access_token
+```
+
+**Security Note**: Avoid hardcoding credentials in scripts. Use environment variables or secure configuration files instead.
+
+```{r env-vars}
+# Store credentials in environment variables
+username <- Sys.getenv("PETROVISOR_USER")
+password <- Sys.getenv("PETROVISOR_PASSWORD")
+discovery_url <- Sys.getenv("PETROVISOR_URL")
+
+token_response <- auth_service$get_access_token(
+  username = username,
+  password = password,
+  discovery_url = discovery_url
+)
+```
+
+## 3. Refresh Token Authentication
+
+Access tokens expire after a certain period (typically 1 hour). Use refresh tokens to obtain new access tokens without re-entering credentials:
+
+```{r refresh-token}
+# Use a refresh token to get a new access token
+token_response <- auth_service$get_access_token(
+  refresh_token = refresh_token,
+  discovery_url = "https://identity.us1.petrovisor.com"
+)
+
+# Update your access token
+access_token <- token_response$access_token
+
+# You'll also get a new refresh token
+refresh_token <- token_response$refresh_token
+```
+
+# Service Provider Authentication
+
+The `ServiceProvider` class can handle authentication automatically, eliminating the need to manually manage tokens in most cases.
+
+**Note**: See `?ServiceProvider` for complete documentation of initialization parameters.
+
+## Direct Token Authentication
+
+Pass a pre-obtained token to the service provider:
+
+```{r sp-token}
+sp <- ServiceProvider$new(
+  url = "https://identity.us1.petrovisor.com",
+  workspace = "MyWorkspace",
+  client_token = access_token
+)
+```
+
+## Automatic Authentication
+
+Let the service provider handle token retrieval:
+
+```{r sp-auto}
+sp <- ServiceProvider$new(
+  url = "https://identity.us1.petrovisor.com",
+  workspace = "MyWorkspace",
+  user = "your_username",
+  password = "your_password"
+)
+
+# The service provider automatically:
+# 1. Contacts the identity server
+# 2. Obtains an access token
+# 3. Configures all services with the token
+```
+
+# Authentication Context
+
+The package includes a global authentication context that stores authentication details and can be used across different parts of your code.
+
+## Using the Authentication Context
+
+The authentication context is automatically set when you create a `ServiceProvider`:
+
+```{r auth-context-auto}
+sp <- ServiceProvider$new(
+  url = "https://identity.us1.petrovisor.com",
+  workspace = "MyWorkspace",
+  user = "your_username",
+  password = "your_password"
+)
+
+# Get the authentication context
+auth_context <- get_auth_context()
+
+# The context contains:
+# - token: The current access token
+# - token_type: Token type (usually "Bearer")
+# - workspace_data_url: Full URL for workspace data operations
+# - user: Current username
+# - workspace: Current workspace name
+```
+
+## Manual Context Management
+
+You can also manually manage the authentication context:
+
+```{r manual-context}
+# Get the global authentication context
+auth_context <- get_auth_context()
+
+# Set authentication details
+auth_context$set_auth(
+  token = access_token,
+  token_type = "Bearer",
+  workspace_data_url = "https://api.us1.petrovisor.com/PetroVisor/API/MyWorkspace/",
+  user = "your_username",
+  workspace = "MyWorkspace"
+)
+
+# Clear authentication (useful for switching users/workspaces)
+auth_context$clear()
+```
+
+## Scoped Authentication with `with_auth_context()`
+
+Execute code with a specific authentication context without affecting the global context:
+
+```{r with-auth-context}
+# Define authentication for a specific operation
+with_auth_context(
+  token = access_token,
+  token_type = "Bearer",
+  workspace_data_url = workspace_url,
+  {
+    # Code here uses the specified authentication
+    sp <- ServiceProvider$new(
+      url = "https://identity.us1.petrovisor.com",
+      workspace = "MyWorkspace",
+      client_token = access_token
+    )
+
+    data <- sp$data$load(...)
+  }
+)
+
+# Authentication context is restored after the block
+```
+
+## Requiring Authentication
+
+Use `require_authentication()` to ensure code only runs when properly authenticated:
+
+```{r require-auth}
+# This function will throw an error if not authenticated
+require_authentication()
+
+# Use in custom functions
+my_data_function <- function() {
+  require_authentication()
+
+  auth_context <- get_auth_context()
+  # ... rest of your code
+}
+```
+
+# Discovery URLs
+
+PetroVisor uses OpenID Connect for authentication. The discovery URL is the base URL of your PetroVisor identity server, which provides authentication endpoints.
+
+## Common Discovery URLs
+
+```{r discovery-urls}
+# US Region 1
+discovery_url <- "https://identity.us1.petrovisor.com"
+
+# EU Region 1
+discovery_url <- "https://identity.eu1.petrovisor.com"
+
+# On-premise installations
+discovery_url <- "https://your-company-petrovisor.com"
+```
+
+## Discovery Document
+
+The authentication service uses the discovery document to find authentication endpoints:
+
+```{r discovery-doc}
+# Get the discovery document (advanced usage)
+discovery_doc <- auth_service$get_discovery_document(
+  "https://identity.us1.petrovisor.com"
+)
+
+# Contains endpoints like:
+# - token_endpoint: Where to get tokens
+# - petrovisor_webapi_endpoint: API base URL
+```
+
+# Token Management Best Practices
+
+## 1. Store Tokens Securely
+
+Never hardcode tokens in your scripts:
+
+```{r secure-tokens}
+# BAD - Don't do this
+token <- "eyJhbGciOiJSUzI1NiIsImtpZCI6..."
+
+# GOOD - Use environment variables
+token <- Sys.getenv("PETROVISOR_TOKEN")
+
+# GOOD - Read from secure file
+token <- readLines("~/.petrovisor/token.txt")[1]
+```
+
+## 2. Handle Token Expiration
+
+Access tokens expire. Implement refresh logic:
+
+```{r token-refresh}
+# Store both access and refresh tokens
+tokens <- list(
+  access = token_response$access_token,
+  refresh = token_response$refresh_token,
+  expires_at = Sys.time() + token_response$expires_in
+)
+
+# Check expiration before API calls
+check_token <- function(tokens, discovery_url) {
+  if (Sys.time() >= tokens$expires_at) {
+    # Token expired, refresh it
+    auth_service <- AuthenticationService$new()
+    new_response <- auth_service$get_access_token(
+      refresh_token = tokens$refresh,
+      discovery_url = discovery_url
+    )
+
+    tokens$access <- new_response$access_token
+    tokens$refresh <- new_response$refresh_token
+    tokens$expires_at <- Sys.time() + new_response$expires_in
+  }
+
+  return(tokens)
+}
+```
+
+## 3. Use API Keys for Automation
+
+For scheduled scripts and automation, API keys are more reliable than username/password:
+
+```{r api-key-automation}
+# In your automated script
+api_key <- Sys.getenv("PETROVISOR_API_KEY")
+discovery_url <- Sys.getenv("PETROVISOR_URL")
+
+auth_service <- AuthenticationService$new()
+token_response <- auth_service$get_access_token(
+  key = api_key,
+  discovery_url = discovery_url
+)
+
+sp <- ServiceProvider$new(
+  url = discovery_url,
+  workspace = Sys.getenv("PETROVISOR_WORKSPACE"),
+  client_token = token_response$access_token
+)
+```
+
+## 4. Separate Credentials by Environment
+
+Use different credentials for development, testing, and production:
+
+```{r env-separation}
+# Set up environment-specific configuration
+config <- list(
+  dev = list(
+    url = "https://identity.dev.petrovisor.com",
+    workspace = "DevWorkspace"
+  ),
+  prod = list(
+    url = "https://identity.us1.petrovisor.com",
+    workspace = "ProductionWorkspace"
+  )
+)
+
+# Select environment
+env <- Sys.getenv("R_ENV", "dev")
+cfg <- config[[env]]
+
+sp <- ServiceProvider$new(
+  url = cfg$url,
+  workspace = cfg$workspace,
+  user = Sys.getenv("PETROVISOR_USER"),
+  password = Sys.getenv("PETROVISOR_PASSWORD")
+)
+```
+
+# Multi-Workspace Access
+
+To work with multiple workspaces, create separate service providers:
+
+```{r multi-workspace}
+# Connect to first workspace
+sp1 <- ServiceProvider$new(
+  url = "https://identity.us1.petrovisor.com",
+  workspace = "Workspace1",
+  user = username,
+  password = password
+)
+
+# Connect to second workspace
+sp2 <- ServiceProvider$new(
+  url = "https://identity.us1.petrovisor.com",
+  workspace = "Workspace2",
+  user = username,
+  password = password
+)
+
+# Load data from both workspaces
+data1 <- sp1$data$load(...)
+data2 <- sp2$data$load(...)
+
+# Combine or compare data
+combined <- merge(data1, data2, ...)
+```
+
+# Troubleshooting
+
+## Common Authentication Errors
+
+### "Failed to retrieve token"
+
+**Cause**: Invalid credentials or network issues
+
+**Solution**: 
+- Verify your username/password or API key
+- Check that the discovery URL is correct
+- Ensure you have network access to the identity server
+
+### "Token endpoint not found"
+
+**Cause**: Invalid discovery URL
+
+**Solution**: 
+- Verify the discovery URL is correct
+- Ensure the URL includes the protocol (https://)
+- Check if the identity server is accessible
+
+### "Unauthorized" errors during API calls
+
+**Cause**: Token expired or invalid
+
+**Solution**: 
+- Refresh your token using the refresh token
+- Re-authenticate to get a new token
+- Check that you're using the correct workspace
+
+## Testing Authentication
+
+Test your authentication setup:
+
+```{r test-auth}
+# Test authentication
+tryCatch({
+  auth_service <- AuthenticationService$new()
+  token_response <- auth_service$get_access_token(
+    username = Sys.getenv("PETROVISOR_USER"),
+    password = Sys.getenv("PETROVISOR_PASSWORD"),
+    discovery_url = "https://identity.us1.petrovisor.com"
+  )
+
+  cat("Authentication successful!\n")
+  cat("Token expires in:", token_response$expires_in, "seconds\n")
+
+}, error = function(e) {
+  cat("Authentication failed:", e$message, "\n")
+})
+```
+
+# Next Steps
+
+Now that you understand authentication, explore these guides:
+
+- **[Getting Started](getting-started.html)**: Overview of the package
+- **[Working with Data](working-with-data.html)**: Loading and saving data
+- **[Repository Service](repository-service.html)**: Managing PetroVisor items
+
+# See Also
+
+- `?AuthenticationService`: Authentication service documentation
+- `?ServiceProvider`: Service provider documentation
+- `?get_auth_context`: Authentication context functions
+- `?with_auth_context`: Scoped authentication
+- `?require_authentication`: Authentication requirement checker
+

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -1,0 +1,716 @@
+---
+title: "Getting Started with Myrconn.PetroVisor.Client"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Getting Started with Myrconn.PetroVisor.Client}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  eval = FALSE
+)
+```
+
+# Introduction
+
+The `Myrconn.PetroVisor.Client` package provides a comprehensive R wrapper for the PetroVisor REST API, enabling you to interact with PetroVisor services directly from R. This package structures API calls into intuitive services:
+
+- **Data Services** (`sp$data`): Load and save time series, depth, static, and PVT data
+- **Repository Services** (`sp$items`): Manage entities, signals, units, and hierarchies
+- **Logging Services** (`sp$logs`): Access and manage log entries
+- **File Services** (`sp$files`): Handle file operations
+- **Tag Entry Services** (`sp$tag_entries`): Work with tag entries
+- **Machine Learning Services** (`sp$ml`): Train and use ML models
+
+## Installation
+
+You can install the package from GitHub using the `remotes` package:
+
+```{r install}
+# Install from GitHub
+remotes::install_github("Datagration/petrovisor-r-api")
+```
+
+## Loading the Package
+
+```{r setup}
+library(Myrconn.PetroVisor.Client)
+```
+
+# Authentication
+
+Before you can use any PetroVisor services, you need to authenticate. The package supports three authentication methods.
+
+## Method 1: API Key Authentication
+
+This is the simplest method if you have an API key:
+
+```{r auth-key}
+# Create an authentication service instance
+auth_service <- AuthenticationService$new()
+
+# Get access token using API key
+token_response <- auth_service$get_access_token(
+  key = "your_api_key_here",
+  discovery_url = "https://identity.us1.petrovisor.com"
+)
+
+# Extract the token
+access_token <- token_response$access_token
+```
+
+## Method 2: Username and Password
+
+If you have username and password credentials:
+
+```{r auth-password}
+auth_service <- AuthenticationService$new()
+
+token_response <- auth_service$get_access_token(
+  username = "your_username",
+  password = "your_password",
+  discovery_url = "https://identity.us1.petrovisor.com"
+)
+
+access_token <- token_response$access_token
+```
+
+## Method 3: Refresh Token
+
+If you have a refresh token from a previous session:
+
+```{r auth-refresh}
+auth_service <- AuthenticationService$new()
+
+token_response <- auth_service$get_access_token(
+  refresh_token = "your_refresh_token",
+  discovery_url = "https://identity.us1.petrovisor.com"
+)
+
+access_token <- token_response$access_token
+```
+
+For more detailed information about authentication, see the [Authentication Guide](authentication.html) vignette.
+
+# Creating a Service Provider
+
+The `ServiceProvider` class is your main entry point for interacting with PetroVisor. It provides access to all available services and handles authentication automatically.
+
+## Using Username and Password
+
+The most common way to create a service provider:
+
+```{r sp-credentials}
+sp <- ServiceProvider$new(
+  url = "https://identity.us1.petrovisor.com",
+  workspace = "YourWorkspaceName",
+  user = "your_username",
+  password = "your_password"
+)
+```
+
+## Using a Token
+
+If you already have an access token:
+
+```{r sp-token}
+sp <- ServiceProvider$new(
+  url = "https://identity.us1.petrovisor.com",
+  workspace = "YourWorkspaceName",
+  client_token = access_token
+)
+```
+
+# Quick Tour of Services
+
+Once you have a `ServiceProvider` instance, you can access all the services through its fields:
+
+## Repository Service (`sp$items`)
+
+Access and manage PetroVisor items like entities and signals:
+
+```{r items-examples}
+# Load all entity names
+entity_names <- sp$items$load_names("Entity")
+
+# Load all signal names
+signal_names <- sp$items$load_names("Signal")
+
+# Load a specific entity by name
+entity <- sp$items$load("Entity", "WellName")
+
+# Create a new entity
+new_entity <- Entity$new(
+  name = "TestWell01",
+  entity_type_name = "Well",
+  alias = "Test Well 01",
+  is_opportunity = FALSE
+)
+sp$items$save("Entity", new_entity)
+
+# Delete an entity
+sp$items$delete("Entity", "TestWell01")
+```
+
+## Data Service (`sp$data`)
+
+Load and save data from PetroVisor:
+
+```{r data-examples}
+# Parse signal strings (signal name with unit in brackets)
+oil_rate <- sp$parse_signal("Oil Rate [bbl/d]")
+gas_rate <- sp$parse_signal("Gas Rate [Mscf/d]")
+
+# Load time series data
+data <- sp$data$load_signals(
+  entities = c("Well1", "Well2"),
+  signals = list(oil_rate, gas_rate),
+  time_increment = "Daily",
+  time_start = "2024-01-01T00:00:00",
+  time_end = "2024-12-31T23:59:59",
+  reshape = TRUE
+)
+
+# The result contains TimeNumericData with columns:
+# - scenario, date, entity, and one column per signal
+head(data$TimeNumericData)
+```
+
+## Logging Service (`sp$logs`)
+
+Access log entries:
+
+```{r logs-examples}
+# Create log entries
+log_entry1 <- LogEntry$new(
+  severity = "Debug",
+  message = "Test log message",
+  category = "R Test",
+  item_type = "Unknown",
+  item_change = "Other"
+)
+
+log_entry2 <- LogEntry$new(
+  severity = "Information",
+  message = "Another test message",
+  category = "R Test",
+  item_type = "Unknown",
+  item_change = "Other"
+)
+
+# Save log entries (takes a list or vector)
+result <- sp$logs$save(c(log_entry1, log_entry2))
+
+# Get available log categories
+categories <- sp$logs$load_categories()
+
+# Load log entries with optional filters
+all_logs <- sp$logs$load()
+
+# Load with specific category filter
+r_test_logs <- sp$logs$load(categories = c("R Test"))
+
+# Load with severity filter
+warnings <- sp$logs$load(severities = c("Warning"))
+
+# Load latest 10 entries
+recent_logs <- sp$logs$load(last_entries = 10)
+
+# Delete log entries (keep last 30 days)
+sp$logs$delete(days_to_keep = 30)
+
+# Delete specific category
+sp$logs$delete(days_to_keep = 0, category = "R Test")
+```
+
+## Utility Functions
+
+The `ServiceProvider` also includes helpful utility functions:
+
+### Unit Conversion
+
+Convert values between units:
+
+```{r unit-conversion}
+# Convert a single value
+converted <- sp$convert_unit(
+  x = 100,
+  source_unit = "bbl/d",
+  target_unit = "m3/d"
+)
+
+# Convert a vector of values
+values <- c(100, 200, 300)
+converted_values <- sp$convert_unit(
+  x = values,
+  source_unit = "bbl/d",
+  target_unit = "m3/d"
+)
+
+# Handle special units
+percent_to_fraction <- sp$convert_unit(10, "%", " ")  # 0.1
+fraction_to_percent <- sp$convert_unit(0.1, " ", "%")  # 10
+```
+
+### Signal Parsing
+
+Parse signal strings that include units:
+
+```{r signal-parsing}
+# Parse a mapped signal string from PetroVisor
+signal <- sp$parse_signal("Oil Production Rate [bbl/d]")
+
+# Access components
+signal$Signal  # "Oil Production Rate"
+signal$Unit    # "bbl/d"
+
+# Use in data operations
+data <- sp$data$load_signals(
+  entities = c("Well1"),
+  signals = list(signal),
+  time_increment = "Daily",
+  time_start = "2024-01-01T00:00:00",
+  time_end = "2024-01-31T23:59:59",
+  reshape = TRUE
+)
+```
+
+### Sending Email
+
+Send emails using PetroVisor's email configuration:
+
+```{r email}
+sp$send_mail(
+  address = "recipient@example.com",
+  subject = "Analysis Complete",
+  body = "The production analysis has been completed successfully."
+)
+```
+
+# Working with Entities
+
+Entities represent wells, fields, reservoirs, and other assets in PetroVisor.
+
+## Creating Entities
+
+```{r create-entity}
+# Create a new entity
+well <- Entity$new(
+  name = "Well-001",
+  entity_type_name = "Well",
+  alias = "Production Well 001",
+  is_opportunity = FALSE
+)
+
+# Save to PetroVisor
+result <- sp$items$save("Entity", well)
+```
+
+## Loading Entities
+
+```{r load-entity}
+# Load a specific entity
+well <- sp$items$load("Entity", "Well-001")
+
+# Get all entity names
+all_entities <- sp$items$load_names("Entity")
+```
+
+## Updating Entities
+
+```{r update-entity}
+# Load entity
+well <- sp$items$load("Entity", "Well-001")
+
+# Modify properties
+well$alias <- "Updated Alias"
+
+# Save changes
+sp$items$save("Entity", well)
+```
+
+## Deleting Entities
+
+```{r delete-entity}
+# Delete an entity
+sp$items$delete("Entity", "Well-001")
+```
+
+# Working with Signals
+
+Signals represent measured or calculated values in PetroVisor. Creating signals requires specifying all required properties.
+
+## Creating Signals
+
+```{r create-signal}
+# Create a comprehensive signal definition
+oil_rate_signal <- Signal$new(
+  name = "Oil Rate",
+  short_name = "qo",
+  measurement_name = "VolumetricFlowRate",
+  storage_unit_name = "bbl/d",
+  aggregation_type = "Sum",
+  container_aggregation_type = "Sum",
+  signal_type = "TimeDependent",
+  default_color = 0,
+  default_line_type = "Solid",
+  setting_name = NULL,
+  labels = list(),
+  description = "Oil production rate"
+)
+
+# Save signal
+sp$items$save("Signal", oil_rate_signal)
+```
+
+## Signal Types
+
+Different signal types are used for different data:
+
+- `"Static"`: Entity-level data that doesn't change
+- `"TimeDependent"`: Numeric data that varies over time
+- `"StringTimeDependent"`: Text data that varies over time
+- `"DepthDependent"`: Numeric data that varies with depth
+- `"StringDepthDependent"`: Text data that varies with depth
+- `"PVT"`: Pressure-Volume-Temperature dependent data
+
+## Loading Signals
+
+```{r load-signal}
+# Load a specific signal
+signal <- sp$items$load("Signal", "Oil Rate")
+
+# Get all signal names
+all_signals <- sp$items$load_names("Signal")
+```
+
+# Working with Data
+
+## Loading Different Data Types
+
+### Static Data
+
+```{r load-static}
+# Load static (non-time-varying) data
+static_data <- sp$data$load_signals(
+  entities = c("Well-001", "Well-002"),
+  signals = lapply(
+    c("Latitude [deg]", "Longitude [deg]"),
+    function(x) {
+      sp$parse_signal(x)
+    }
+  ),
+  reshape = TRUE
+)
+
+# Access the data
+static_data$StaticNumericData
+```
+
+### Time Series Data
+
+```{r load-time}
+# Load daily time series data
+time_data <- sp$data$load_signals(
+  entities = c("Well-001"),
+  signals = lapply(
+    c("Oil Rate [bbl/d]", "Gas Rate [Mscf/d]"),
+    function(x) {
+      sp$parse_signal(x)
+    }
+  ),
+  time_increment = "Daily",
+  time_start = "2024-01-01T00:00:00",
+  time_end = "2024-01-31T23:59:59",
+  reshape = TRUE
+)
+
+# Access the data
+time_data$TimeNumericData
+```
+
+### Depth Data
+
+```{r load-depth}
+# Load depth-dependent data
+depth_data <- sp$data$load_signals(
+  entities = c("Well-001"),
+  signals = lapply(
+    c("Porosity [frac]", "Permeability [mD]"),
+    function(x) {
+      sp$parse_signal(x)
+    }
+  ),
+  depth_increment = "Meter",
+  depth_start = 5000,
+  depth_end = 7000,
+  reshape = TRUE
+)
+
+# Access the data
+depth_data$DepthNumericData
+```
+
+### PVT Data
+
+```{r load-pvt}
+# Load PVT data
+pvt_data <- sp$data$load_signals(
+  entities = c("Reservoir-A"),
+  signals = lapply(
+    c("Oil FVF [rb/stb]", "Gas FVF [rcf/scf]"),
+    function(x) {
+      sp$parse_signal(x)
+    }
+  ),
+  pressure_unit = "psi",
+  temperature_unit = "degC",
+  reshape = TRUE
+)
+
+# Access the data
+pvt_data$PVTNumericData
+```
+
+## Saving Data
+
+### Saving Time Series Data
+
+```{r save-time}
+# Prepare data frame with correct structure
+time_data <- data.frame(
+  scenario = c("", ""),
+  date = c("2024-01-01T00:00:00", "2024-01-02T00:00:00"),
+  entity = c("Well-001", "Well-001"),
+  oil_rate = c(500, 520),
+  gas_rate = c(1500, 1560)
+)
+
+# Column names must match signal names (without units)
+colnames(time_data) <- c(
+  "scenario", "date", "entity",
+  "Oil Rate", "Gas Rate"
+)
+
+# Save data
+result <- sp$data$save_signals(
+  "TimeNumeric",  # Data type
+  time_data,
+  signals = lapply(
+    c("Oil Rate [bbl/d]", "Gas Rate [Mscf/d]"),
+    function(x) {
+      sp$parse_signal(x)
+    }
+  )
+)
+```
+
+### Saving Static Data
+
+```{r save-static}
+# Prepare static data
+static_data <- data.frame(
+  scenario = c(""),
+  entity = c("Well-001"),
+  latitude = c(45.123),
+  longitude = c(-110.456)
+)
+
+colnames(static_data) <- c(
+  "scenario", "entity",
+  "Latitude", "Longitude"
+)
+
+# Save static data
+result <- sp$data$save_signals(
+  "StaticNumeric",
+  static_data,
+  signals = lapply(
+    c("Latitude [deg]", "Longitude [deg]"),
+    function(x) {
+      sp$parse_signal(x)
+    }
+  )
+)
+```
+
+## Deleting Data
+
+```{r delete-data}
+# Delete signal data for specific entities
+result <- sp$data$delete_signals(
+  entities = c("Well-001", "Well-002"),
+  signals = c("Oil Rate", "Gas Rate"),
+  time_start = "2024-01-01T00:00:00",
+  time_end = "2024-01-31T23:59:59"
+)
+```
+
+# Working with Reference Tables
+
+Reference tables are structured tabular data with defined schemas.
+
+## Creating a Reference Table
+
+```{r create-ref-table}
+# Define columns
+key_column <- ReferenceTableColumn$new(
+  name = "ID",
+  column_type = "Numeric",
+  unit_name = " "
+)
+
+name_column <- ReferenceTableColumn$new(
+  name = "Name",
+  column_type = "String",
+  unit_name = " "
+)
+
+value_column <- ReferenceTableColumn$new(
+  name = "Value",
+  column_type = "Numeric",
+  unit_name = "m3"
+)
+
+# Create reference table
+ref_table <- ReferenceTable$new(
+  name = "Parameters",
+  description = "Parameter lookup table",
+  key = key_column,
+  values = list(name_column, value_column)
+)
+
+# Save reference table definition
+sp$items$save("ReferenceTable", ref_table)
+```
+
+## Saving Reference Table Data
+
+```{r save-ref-data}
+# Prepare data
+ref_data <- data.frame(
+  Entity = c(NA, "Well-001"),
+  Timestamp = c(NA, "2024-01-01T00:00:00"),
+  ID = c(1, 2),
+  Name = c("Parameter1", "Parameter2"),
+  Value = c(100, 200)
+)
+
+# Save data
+result <- sp$data$save_reference_table("Parameters", ref_data)
+```
+
+## Loading Reference Table Data
+
+```{r load-ref-data}
+# Load reference table data
+data <- sp$data$load_reference_table("Parameters")
+```
+
+# Common Patterns
+
+## Handling Missing Values
+
+Use `NA` or `NaN` for missing numeric values:
+
+```{r missing-values}
+# Data with missing values
+data <- data.frame(
+  scenario = c("", "", ""),
+  date = c("2024-01-01T00:00:00", "2024-01-02T00:00:00", "2024-01-03T00:00:00"),
+  entity = c("Well-001", "Well-001", "Well-001"),
+  oil_rate = c(500, NA, 520),  # Missing value on Jan 2
+  gas_rate = c(1500, 1550, NaN)  # NaN on Jan 3
+)
+
+colnames(data) <- c("scenario", "date", "entity", "Oil Rate", "Gas Rate")
+
+# PetroVisor handles NA/NaN appropriately
+result <- sp$data$save_signals("TimeNumeric", data, signals)
+```
+
+## Working with Multiple Entities
+
+```{r multiple-entities}
+# Get all entity names
+all_entities <- sp$items$load_names("Entity")
+
+# Filter to specific entity types (e.g., wells starting with "PROD-")
+production_wells <- all_entities[grepl("^PROD-", all_entities)]
+
+# Load data for all production wells
+production_data <- sp$data$load_signals(
+  entities = production_wells,
+  signals = list(sp$parse_signal("Oil Rate [bbl/d]")),
+  time_increment = "Monthly",
+  time_start = "2024-01-01T00:00:00",
+  time_end = "2024-12-31T23:59:59",
+  reshape = TRUE
+)
+```
+
+## Error Handling
+
+Always wrap API calls in error handling:
+
+```{r error-handling}
+# Wrap operations in tryCatch
+result <- tryCatch({
+  sp$data$save_signals("TimeNumeric", my_data, my_signals)
+}, error = function(e) {
+  cat("Error saving data:", e$message, "\n")
+  return(NULL)
+})
+
+if (!is.null(result) && result$status_code == 200) {
+  cat("Data saved successfully\n")
+}
+```
+
+# Next Steps
+
+Now that you understand the basics, explore these guides for more detailed information:
+
+- **[Authentication Guide](authentication.html)**: Deep dive into authentication methods and best practices
+- **[Working with Data](working-with-data.html)**: Comprehensive guide to loading and saving different data types
+- **[Repository Service](repository-service.html)**: Managing entities, signals, hierarchies, and more
+- **[Machine Learning](machine-learning.html)**: Training models and making predictions
+
+# Getting Help
+
+- Check the function documentation: `?ServiceProvider`, `?DataServices`, etc.
+- Browse the [reference documentation](../reference/index.html)
+- Visit the [GitHub repository](https://github.com/Datagration/petrovisor-r-api) to report issues or request features
+
+# Important Notes
+
+## Date/Time Format
+
+Always use ISO 8601 format for dates and times:
+- Correct: `"2024-01-01T00:00:00"`
+- Incorrect: `"2024-01-01"` or `"01/01/2024"`
+
+## Column Names in Data Frames
+
+When saving data, column names in your data frame must match the signal names (without units):
+- Signal: `"Oil Rate [bbl/d]"`
+- Column name: `"Oil Rate"`
+
+## Data Type Names
+
+Use the correct data type names when saving:
+- `"StaticNumeric"`, `"StaticString"`
+- `"TimeNumeric"`, `"TimeString"`
+- `"DepthNumeric"`, `"DepthString"`
+- `"PVTNumeric"`
+
+## Units with Special Characters
+
+Some units require special handling:
+- Space (dimensionless): `" "`
+- Percent: `"%"`
+- Units with slashes: handled automatically (e.g., `"bbl/d"`)

--- a/vignettes/machine-learning.Rmd
+++ b/vignettes/machine-learning.Rmd
@@ -1,0 +1,698 @@
+---
+title: "Machine Learning with PetroVisor"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Machine Learning with PetroVisor}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  eval = FALSE
+)
+```
+
+```{r setup}
+library(Myrconn.PetroVisor.Client)
+```
+
+# Overview
+
+The `MlTrainingService` provides machine learning capabilities within PetroVisor. You can train models, make predictions, and manage ML workflows directly from R. This guide covers the complete ML workflow with tested examples.
+
+# Setup
+
+Create a service provider to access the ML service:
+
+```{r service-provider}
+sp <- ServiceProvider$new(
+  url = "https://identity.us1.petrovisor.com",
+  workspace = "YourWorkspace",
+  user = "your_username",
+  password = "your_password"
+)
+
+# The ML service is accessible via sp$ml
+```
+
+# Machine Learning Workflow
+
+The typical ML workflow in PetroVisor:
+
+1. **Prepare Data**: Create entities and save signal data
+2. **Create Model**: Define model with table formula and label
+3. **Configure Training**: Set training options with scope and entity set
+4. **Train**: Submit training request
+5. **Monitor**: Check training status
+6. **Evaluate**: Review training results
+7. **Save**: Save the best trained model
+8. **Predict**: Use the model for predictions
+
+# Data Preparation
+
+Before training, you need entities and signals with data.
+
+## Creating Test Entities and Signals
+
+```{r prepare-data}
+# Create entities for training
+entity_names <- c()
+for (i in 1:50) {
+  entity_name <- paste0("MLTestEntity_", sprintf("%02d", i))
+  entity_names <- c(entity_names, entity_name)
+
+  entity <- Entity$new(
+    name = entity_name,
+    entity_type_name = "Well",
+    alias = paste0("MLE", sprintf("%02d", i)),
+    is_opportunity = FALSE
+  )
+
+  sp$items$save("Entity", entity)
+}
+
+# Create predictor signal (input feature)
+predictor_signal <- Signal$new(
+  name = "ml test predictor signal",
+  short_name = "mlpred",
+  measurement_name = "Length",
+  storage_unit_name = "m",
+  aggregation_type = "Sum",
+  container_aggregation_type = "Sum",
+  signal_type = "Static",
+  default_color = 3711337,
+  default_line_type = "Solid",
+  setting_name = NULL,
+  labels = list(),
+  description = "ML test predictor feature"
+)
+
+sp$items$save("Signal", predictor_signal)
+
+# Create target signal (output to predict)
+target_signal <- Signal$new(
+  name = "ml test target signal",
+  short_name = "mltarget",
+  measurement_name = "Volume",
+  storage_unit_name = "m3",
+  aggregation_type = "Sum",
+  container_aggregation_type = "Sum",
+  signal_type = "Static",
+  default_color = 16711680,
+  default_line_type = "Solid",
+  setting_name = NULL,
+  labels = list(),
+  description = "ML test target to predict"
+)
+
+sp$items$save("Signal", target_signal)
+
+# Generate correlated data
+set.seed(42)
+predictor_values <- runif(50, min = 10, max = 100)
+noise <- rnorm(50, mean = 0, sd = 5)
+target_values <- 2.5 * predictor_values + 50 + noise
+
+# Save data
+static_data <- data.frame(
+  scenario = rep("", 50),
+  entity = entity_names,
+  stringsAsFactors = FALSE
+)
+static_data[[predictor_signal$name]] <- predictor_values
+static_data[[target_signal$name]] <- target_values
+
+result <- sp$data$save_signals(
+  "StaticNumeric",
+  static_data,
+  signals = lapply(
+    c(
+      paste0(predictor_signal$name,
+             " [",
+             predictor_signal$storage_unit_name,
+             "]"),
+      paste0(target_signal$name,
+             " [",
+             target_signal$storage_unit_name,
+             "]")
+    ),
+    function(x) {
+      sp$parse_signal(x)
+    }
+  )
+)
+```
+
+# Creating and Configuring Models
+
+## Basic Model Creation
+
+```{r basic-model}
+# Create table formula - defines features and target
+table_formula <- paste0('Table "ML Training Data"
+  Column "predictor" in "', predictor_signal$storage_unit_name, '"
+    "', predictor_signal$name, '" in "', predictor_signal$storage_unit_name, '"
+  End Column
+  Column "target" in "', target_signal$storage_unit_name, '"
+    "', target_signal$name, '" in "', target_signal$storage_unit_name, '"
+  End Column
+End Table')
+
+# Create model
+model <- MLModel$new(
+  name = "Oil Rate Predictor",
+  type = "Regression",
+  table_formula = table_formula,
+  label_column_name = "target"
+)
+
+# Model is not ready to train yet - need to set training options
+```
+
+## Creating Scope and Entity Set
+
+Before setting training options, create scope and entity set:
+
+```{r create-scope-entity-set}
+# Create entity set
+entity_set <- EntitySet$new(
+  name = "ML Training Entities",
+  entities = list(),  # Can provide entity objects or leave empty
+  formula = paste0('Entity Set "ML Training Entities"
+\t"MLTestEntity_01"
+\t"MLTestEntity_02"
+\t"MLTestEntity_03"
+End Set')
+)
+
+# Create scope
+scope <- Scope$new(
+  name = "ML Training Scope",
+  start = "2024-01-01T00:00:00.000Z",
+  end = "2024-01-01T00:00:00.000Z",
+  time_increment = "Daily",
+  depth_increment = "Meter",
+  start_depth = 0,
+  end_depth = 5000,
+  formula = 'Scope "At Date"
+\tBetween #01/01/2024#
+\tAnd #01/01/2024#
+\tStep Daily
+End Scope'
+)
+```
+
+## Setting Training Options
+
+Training options must be set before other configurations:
+
+```{r set-training-options}
+# Set training options (required before other model configurations)
+model$set_training_options(
+  scope = scope,
+  entity_set = entity_set,
+  test_fraction = 0.2,           # 20% for testing
+  validation_fraction = 0.2,      # 20% for validation
+  time_to_train = 60              # Training time in seconds
+)
+```
+
+## Configuring Preprocessing
+
+After setting training options, you can configure preprocessing:
+
+```{r preprocessing}
+# Enable specific preprocessing methods
+model$set_preprocessing(
+  c("MinMax", "BoxCox", "RobustScaling"),
+  apply_pre_processors_before_training = FALSE
+)
+```
+
+## Configuring Outlier Filtering
+
+```{r outlier-filtering}
+# Set outlier filtering method
+model$set_outlier_filtering("CooksDistance")
+
+# Options: "CooksDistance", "IQR", etc.
+```
+
+## Advanced: Neural Network Options
+
+```{r neural-network}
+# Configure neural network (after setting training options)
+model$set_neural_network_options(
+  library = "TensorFlow",
+  optimizer = "Adam",
+  learning_rate = 0.001,
+  epochs = 100,
+  batch_size = 64,
+  dense_layers = 3,
+  neurons = 128
+)
+```
+
+## Advanced: Custom Training Options
+
+```{r custom-training}
+# Set custom training (e.g., GAM)
+model$set_custom_training(
+  training_type = "Gam",
+  enable_pruning = TRUE,
+  learning_rate = 0.05,
+  maximum_bin_count_per_feature = 200,
+  minimum_example_count_per_leaf = 10,
+  max_iterations = 1500
+)
+```
+
+## Saving Model Configuration
+
+```{r save-model-config}
+# Save the model configuration
+result <- sp$items$save("MLModel", model)
+
+if (result$status_code == 201) {
+  cat("Model configuration saved successfully\n")
+}
+```
+
+# Training Models
+
+## Starting Training
+
+```{r start-training}
+# Train the model
+training_request <- sp$ml$train(model)
+
+# Get request ID for monitoring
+request_id <- training_request$id
+cat("Training started with request ID:", request_id, "\n")
+```
+
+## Monitoring Training Progress
+
+```{r monitor-training}
+# Check training status
+status <- sp$ml$get_training_status(request_id)
+cat("Status:", status$status, "\n")
+
+# Status values: "Unknown", "Waiting", "Training", "Starting",
+#                "Ready", "Completed", "Failed", "Canceled", "Canceling"
+
+# Poll for completion
+wait_for_training <- function(sp, request_id, max_wait = 600, interval = 30) {
+  start_time <- Sys.time()
+
+  repeat {
+    status <- sp$ml$get_training_status(request_id)
+    cat("Status:", status$status, "\n")
+
+    if (status$status == "Ready") {
+      cat("Training completed successfully!\n")
+      break
+    }
+
+    if (status$status %in% c("Failed", "Canceled")) {
+      stop("Training failed or was canceled")
+    }
+
+    elapsed <- as.numeric(difftime(Sys.time(), start_time, units = "secs"))
+    if (elapsed > max_wait) {
+      stop("Training timed out")
+    }
+
+    Sys.sleep(interval)
+  }
+}
+
+# Wait for training to complete
+wait_for_training(sp, request_id)
+```
+
+## Getting Training Results
+
+```{r training-results}
+# Get detailed training results (after training completes)
+results <- sp$ml$get_training_results(request_id)
+
+# results is an MLTrainingResults object
+cat("Training results retrieved\n")
+```
+
+## Evaluating Results
+
+```{r evaluate-results}
+# Get best performing models
+best_models <- results$get_best_models()
+
+# Check if we have any best models
+if (length(best_models) > 0) {
+  best <- best_models[[1]]
+
+  cat("Best Model:\n")
+  cat("  Trainer:", best$trainer_name, "\n")
+
+  # Metrics are in the outcome$values list
+  if (!is.null(best$outcome) && length(best$outcome$values) > 0) {
+    cat("  Validation Metrics:\n")
+    for (metric in best$outcome$values) {
+      cat("    ", metric$name, ":", metric$value, "\n")
+    }
+  }
+
+  # Test metrics are in outcome$test_values
+  if (!is.null(best$outcome) && length(best$outcome$test_values) > 0) {
+    cat("  Test Metrics:\n")
+    for (metric in best$outcome$test_values) {
+      cat("    ", metric$name, ":", metric$value, "\n")
+    }
+  }
+}
+```
+
+## Saving the Best Model
+
+```{r save-best-model}
+# Save the best model to PetroVisor
+save_result <- sp$ml$save_best_model(
+  model = model,
+  best_models = best_models,
+  request_id = request_id,
+  rank = 1  # Save the top-ranked model
+)
+
+cat("Best model saved\n")
+```
+
+# Making Predictions
+
+## Preparing Prediction Data
+
+```{r prep-prediction}
+# Prepare input values for prediction
+# Must match the features used in training
+prediction_values <- c(15, 25, 35, 45, 55)
+```
+
+## Making Predictions
+
+```{r make-predictions}
+# Make predictions using trained model
+predictions <- sp$ml$predict(
+  model_name = model$name,
+  data = prediction_values
+)
+
+# predictions is a list where each element has:
+# - Value: predicted value
+# - Score: confidence score
+# - Probability: probability (for classification)
+
+# Extract predicted values
+predicted_values <- sapply(predictions, function(p) p$Value)
+cat("Predictions:", predicted_values, "\n")
+```
+
+## Batch Predictions
+
+```{r batch-predictions}
+# Load historical data
+historical_data <- sp$data$load_signals(
+  entities = c("MLTestEntity_01", "MLTestEntity_02"),
+  signals = list(sp$parse_signal(paste0(predictor_signal$name, " [m]"))),
+  reshape = TRUE
+)
+
+# Extract predictor values
+predictor_vals <- historical_data$StaticNumericData[[predictor_signal$name]]
+
+# Make predictions
+batch_predictions <- sp$ml$predict(
+  model_name = model$name,
+  data = predictor_vals
+)
+
+# Extract values
+predicted <- sapply(batch_predictions, function(p) p$Value)
+```
+
+# Model Management
+
+## Loading Trained Models
+
+```{r load-model}
+# Load a saved model from repository
+trained_model <- sp$items$load("MLModel", "Oil Rate Predictor")
+
+# Check if model is trained
+if (!is.null(trained_model$trained_models) &&
+      length(trained_model$trained_models) > 0) {
+  cat("Model is trained and ready for predictions\n")
+}
+```
+
+## Listing Models
+
+```{r list-models}
+# Get all ML model names
+model_names <- sp$items$load_names("MLModel")
+
+# Load and summarize models
+for (name in model_names) {
+  model <- sp$items$load("MLModel", name)
+  cat("Model:", model$name, "\n")
+  cat("  Type:", model$type, "\n")
+  cat("  Trained:", !is.null(model$trained_models) &&
+        length(model$trained_models) > 0, "\n\n")
+}
+```
+
+## Deleting Models
+
+```{r delete-model}
+# Delete a model
+sp$items$delete("MLModel", "Old Model Name")
+```
+
+# Model Types
+
+PetroVisor supports different model types:
+
+```{r model-types}
+# Regression (default)
+regression_model <- MLModel$new(
+  name = "Regression Model",
+  type = "Regression",
+  table_formula = table_formula,
+  label_column_name = "target"
+)
+
+# Binary Classification
+binary_model <- MLModel$new(
+  name = "Binary Classification Model",
+  type = "BinaryClassification",
+  table_formula = table_formula,
+  label_column_name = "category"
+)
+
+# Multiple Classification
+multi_model <- MLModel$new(
+  name = "Multi-Class Model",
+  type = "MultipleClassification",
+  table_formula = table_formula,
+  label_column_name = "class"
+)
+
+# Clustering (no label needed)
+cluster_model <- MLModel$new(
+  name = "Clustering Model",
+  type = "Clustering",
+  table_formula = table_formula
+)
+```
+
+# Complete Example
+
+Here's a complete end-to-end example:
+
+```{r complete-example}
+# 1. Create and save model configuration
+model <- MLModel$new(
+  name = "Complete Example Model",
+  type = "Regression",
+  table_formula = table_formula,
+  label_column_name = "target"
+)
+
+# 2. Configure model
+model$set_training_options(scope, entity_set,
+                           test_fraction = 0.2,
+                           validation_fraction = 0.2,
+                           time_to_train = 60)
+
+model$set_preprocessing(
+  methods = c("MinMax", "BoxCox", "RobustScaling"),
+  apply_pre_processors_before_training = FALSE
+)
+model$set_outlier_filtering("CooksDistance")
+
+# 3. Save configuration
+sp$items$save("MLModel", model)
+
+# 4. Train model
+request <- sp$ml$train(model)
+cat("Training request ID:", request$id, "\n")
+
+# 5. Wait for training
+wait_for_training(sp, request$id)
+
+# 6. Get results
+results <- sp$ml$get_training_results(request$id)
+best_models <- results$get_best_models()
+
+# 7. Save best model
+sp$ml$save_best_model(model, best_models, request$id)
+
+# 8. Make predictions
+test_values <- c(20, 40, 60, 80)
+predictions <- sp$ml$predict(model$name, test_values)
+
+# 9. Extract and use predictions
+predicted_values <- sapply(predictions, function(p) p$Value)
+cat("Predictions:", predicted_values, "\n")
+```
+
+# Best Practices
+
+## 1. Use Sufficient Training Data
+
+```{r best-data}
+# Ensure you have enough data points
+# Rule of thumb: at least 10x the number of features
+# For 5 features, aim for 50+ training examples
+```
+
+## 2. Split Data Appropriately
+
+```{r best-split}
+# Use typical splits:
+model$set_training_options(
+  scope, entity_set,
+  test_fraction = 0.2,        # 20% for testing
+  validation_fraction = 0.2,  # 20% for validation
+  time_to_train = 300         # Adequate training time
+)
+```
+
+## 3. Handle Training Errors
+
+```{r best-errors}
+# Wrap training in error handling
+training_result <- tryCatch({
+  request <- sp$ml$train(model)
+  wait_for_training(sp, request$id)
+  sp$ml$get_training_results(request$id)
+}, error = function(e) {
+  cat("Training failed:", e$message, "\n")
+  return(NULL)
+})
+
+if (!is.null(training_result)) {
+  # Process results
+  best_models <- training_result$get_best_models()
+}
+```
+
+## 4. Version Your Models
+
+```{r best-versioning}
+# Use naming conventions for model versions
+model_name <- paste0("OilRatePredictor_v", format(Sys.Date(), "%Y%m%d"))
+
+model <- MLModel$new(
+  name = model_name,
+  type = "Regression",
+  table_formula = table_formula,
+  label_column_name = "target",
+  description = paste("Trained on", Sys.Date())
+)
+```
+
+## 5. Document Models
+
+```{r best-documentation}
+# Include comprehensive descriptions
+model <- MLModel$new(
+  name = "Production Predictor v1",
+  type = "Regression",
+  table_formula = table_formula,
+  label_column_name = "target",
+  description = paste(
+    "Predicts oil production rate from pressure and temperature.",
+    "Features: Pressure, Temperature.",
+    "Training data: 2024, 50 wells.",
+    "Created:", Sys.Date()
+  )
+)
+```
+
+# Troubleshooting
+
+## Issue: "You must call set_training_options first"
+
+**Cause**: Trying to set preprocessing/custom training before training options
+
+**Solution**: Always call `set_training_options()` before other configurations
+
+```{r fix-order}
+# Correct order:
+model$set_training_options(scope, entity_set)  # First
+model$set_preprocessing(...)                    # Then other configs
+```
+
+## Issue: Training fails with insufficient data
+
+**Cause**: Not enough training examples
+
+**Solution**: Ensure sufficient data points and check data quality
+
+```{r fix-data}
+# Check data availability
+data <- sp$data$load_signals(entities, signals, reshape = TRUE)
+cat("Data points:", nrow(data$StaticNumericData), "\n")
+```
+
+## Issue: Predictions are unrealistic
+
+**Cause**: Input values outside training range
+
+**Solution**: Validate prediction inputs
+
+```{r fix-predictions}
+# Check that prediction inputs are within training data range
+training_range <- range(predictor_values, na.rm = TRUE)
+prediction_range <- range(test_values, na.rm = TRUE)
+
+if (prediction_range[1] < training_range[1] ||
+      prediction_range[2] > training_range[2]) {
+  warning("Prediction inputs outside training data range")
+}
+```
+
+# Next Steps
+
+- **[Working with Data](working-with-data.html)**: Learn about loading training data
+- **[Repository Service](repository-service.html)**: Manage ML models and related items
+- **[Getting Started](getting-started.html)**: Package overview
+
+# See Also
+
+- `?MlTrainingService`: ML training service documentation
+- `?MLModel`: ML model class documentation
+- Test files in `tests/testthat/test_machine_learning.R` and 
+  `tests/testthat/test_ml_training_service.R` for working examples

--- a/vignettes/repository-service.Rmd
+++ b/vignettes/repository-service.Rmd
@@ -1,0 +1,678 @@
+---
+title: "Managing Items with Repository Service"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Managing Items with Repository Service}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  eval = FALSE
+)
+```
+
+```{r setup}
+library(Myrconn.PetroVisor.Client)
+```
+
+# Overview
+
+The `RepositoryService` provides access to PetroVisor's repository of items, including entities, signals, units, hierarchies, and more. This service allows you to list, load, create, update, and delete these items.
+
+# Setup
+
+Create a service provider to access the repository service:
+
+```{r service-provider}
+sp <- ServiceProvider$new(
+  url = "https://identity.us1.petrovisor.com",
+  workspace = "YourWorkspace",
+  user = "your_username",
+  password = "your_password"
+)
+
+# The repository service is accessible via sp$items
+```
+
+# Core Operations
+
+The repository service provides four main operations for all item types:
+
+1. **`load_names(type)`**: Get a list of all item names
+2. **`load(type, name)`**: Retrieve a specific item by name
+3. **`save(type, object)`**: Create or update an item
+4. **`delete(type, name)`**: Remove an item by name
+
+These are the **only** methods available - there are no filtering or search methods.
+
+## Loading Item Names
+
+Get all names for a specific item type:
+
+```{r load-names}
+# Load all entity names
+entity_names <- sp$items$load_names("Entity")
+
+# Load all signal names
+signal_names <- sp$items$load_names("Signal")
+
+# Load all unit names
+unit_names <- sp$items$load_names("Unit")
+
+# Load all hierarchy names
+hierarchy_names <- sp$items$load_names("Hierarchy")
+```
+
+## Loading Specific Items
+
+Load a specific item by name:
+
+```{r load-item}
+# Load a specific entity
+well <- sp$items$load("Entity", "Well-001")
+
+# Load a specific signal
+oil_rate_signal <- sp$items$load("Signal", "Oil Rate")
+
+# Load a specific unit
+unit <- sp$items$load("Unit", "bbl/d")
+```
+
+## Saving Items
+
+Create or update items:
+
+```{r save-item}
+# Create a new entity
+new_well <- Entity$new(
+  name = "Well-123",
+  entity_type_name = "Well",
+  alias = "Production Well 123",
+  is_opportunity = FALSE
+)
+
+# Save the entity (creates or updates)
+result <- sp$items$save("Entity", new_well)
+
+# Check result
+if (result$status_code == 201) {
+  cat("Entity created successfully\n")
+}
+```
+
+## Deleting Items
+
+Remove items by name:
+
+```{r delete-item}
+# Delete an entity
+result <- sp$items$delete("Entity", "Well-123")
+
+# Check result
+if (result$status_code == 200) {
+  cat("Entity deleted successfully\n")
+}
+
+# Trying to load deleted item will error
+# sp$items$load("Entity", "Well-123")  # This will throw an error
+```
+
+# Working with Entities
+
+Entities are the primary objects in PetroVisor (wells, fields, reservoirs, etc.).
+
+## Creating Entities
+
+```{r create-entity}
+# Create a new well entity
+well <- Entity$new(
+  name = "Well-456",
+  entity_type_name = "Well",
+  alias = "Injection Well 456",
+  is_opportunity = FALSE
+)
+
+# Save to PetroVisor
+result <- sp$items$save("Entity", well)
+```
+
+## Loading Entities
+
+```{r load-entities}
+# Get all entity names
+all_entities <- sp$items$load_names("Entity")
+
+# Load a specific entity
+well <- sp$items$load("Entity", "Well-001")
+
+# Access entity properties
+cat("Name:", well$name, "\n")
+cat("Type:", well$entity_type_name, "\n")
+cat("Alias:", well$alias, "\n")
+```
+
+## Updating Entities
+
+```{r update-entity}
+# Load existing entity
+well <- sp$items$load("Entity", "Well-456")
+
+# Modify properties
+well$alias <- "Updated Alias"
+
+# Save changes (same save method)
+result <- sp$items$save("Entity", well)
+```
+
+## Filtering Entities (Manual)
+
+Since there's no `load_by_filter()` method, you need to filter manually:
+
+```{r filter-entities}
+# Get all entity names
+all_entities <- sp$items$load_names("Entity")
+
+# Filter by pattern (e.g., wells starting with "PROD-")
+production_wells <- all_entities[grepl("^PROD-", all_entities)]
+
+# Filter to specific names
+specific_wells <-
+  all_entities[all_entities %in% c("Well-001", "Well-002", "Well-003")]
+
+# Load filtered entities
+well_objects <- lapply(production_wells, function(name) {
+  sp$items$load("Entity", name)
+})
+```
+
+# Working with Entity Types
+
+Entity types define categories of entities (Well, Field, Reservoir, etc.).
+
+## Loading Entity Types
+
+```{r entity-types}
+# Get all entity type names
+entity_type_names <- sp$items$load_names("EntityType")
+
+# Load a specific entity type
+well_type <- sp$items$load("EntityType", "Well")
+
+# Access properties
+cat("Name:", well_type$name, "\n")
+```
+
+## Creating Custom Entity Types
+
+```{r create-entity-type}
+# Create a new entity type
+custom_type <- EntityType$new(
+  name = "CustomAsset",
+  image = "default"  # Or base64 encoded image
+)
+
+# Save entity type
+result <- sp$items$save("EntityType", custom_type)
+```
+
+# Working with Signals
+
+Signals represent measured or calculated values in PetroVisor. **Creating signals requires ALL fields.**
+
+## Loading Signals
+
+```{r load-signals}
+# Get all signal names
+all_signals <- sp$items$load_names("Signal")
+
+# Load a specific signal
+oil_rate <- sp$items$load("Signal", "Oil Rate")
+
+# Access signal properties
+cat("Name:", oil_rate$name, "\n")
+cat("Storage Unit:", oil_rate$storage_unit_name, "\n")
+cat("Signal Type:", oil_rate$signal_type, "\n")
+```
+
+## Creating Signals
+
+Signals require **all** of these fields:
+
+```{r create-signal}
+# Create a comprehensive signal definition
+new_signal <- Signal$new(
+  name = "Custom Production Rate",
+  short_name = "cpr",
+  measurement_name = "VolumetricFlowRate",
+  storage_unit_name = "bbl/d",
+  aggregation_type = "Sum",
+  container_aggregation_type = "Sum",
+  signal_type = "TimeDependent",
+  default_color = 0,
+  default_line_type = "Solid",
+  setting_name = NULL,
+  labels = list(),
+  description = "Custom calculated production rate"
+)
+
+# Save signal
+result <- sp$items$save("Signal", new_signal)
+```
+
+## Signal Types
+
+Different signal types for different data:
+
+- `"Static"`: Entity-level data that doesn't change
+- `"TimeDependent"`: Numeric data varying over time
+- `"StringTimeDependent"`: Text data varying over time
+- `"DepthDependent"`: Numeric data varying with depth
+- `"StringDepthDependent"`: Text data varying with depth
+- `"PVT"`: Pressure-Volume-Temperature dependent data
+
+## Signal Properties Reference
+
+- **name**: Signal identifier (required)
+- **short_name**: Abbreviated name (required)
+- **measurement_name**: Type of measurement (e.g., "Length", "Volume", "Dimensionless") (required)
+- **storage_unit_name**: Unit for storage (e.g., "m", "m3", " ") (required)
+- **aggregation_type**: How to aggregate (e.g., "Sum", "Average") (required)
+- **container_aggregation_type**: Container aggregation (required)
+- **signal_type**: Type of signal (see above) (required)
+- **default_color**: Numeric color code (required)
+- **default_line_type**: Line style (e.g., "Solid", "Dash") (required)
+- **setting_name**: Optional setting reference (can be NULL)
+- **labels**: List of labels (can be empty list)
+- **description**: Description text (required)
+
+# Working with Units
+
+Units define measurement systems in PetroVisor.
+
+## Loading Units
+
+```{r load-units}
+# Get all unit names
+all_units <- sp$items$load_names("Unit")
+
+# Load a specific unit
+bbl_d <- sp$items$load("Unit", "bbl/d")
+
+# Access unit properties
+cat("Name:", bbl_d$name, "\n")
+cat("Measurement:", bbl_d$unit_measurement_name, "\n")
+```
+
+## Unit Measurements
+
+Units belong to unit measurements:
+
+```{r unit-measurements}
+# Load all unit measurement names
+measurements <- sp$items$load_names("UnitMeasurement")
+
+# Load a specific measurement
+flow_rate <- sp$items$load("UnitMeasurement", "VolumetricFlowRate")
+
+# See all units in this measurement
+cat("Units:", paste(flow_rate$unit_names, collapse = ", "), "\n")
+```
+
+# Working with Reference Tables
+
+Reference tables define structured data schemas.
+
+## Creating Reference Tables
+
+```{r create-ref-table}
+# Define columns
+key_column <- ReferenceTableColumn$new(
+  name = "ID",
+  column_type = "Numeric",
+  unit_name = " "
+)
+
+name_column <- ReferenceTableColumn$new(
+  name = "Name",
+  column_type = "String",
+  unit_name = " "
+)
+
+value_column <- ReferenceTableColumn$new(
+  name = "Value",
+  column_type = "Numeric",
+  unit_name = "m3"
+)
+
+# Create reference table
+ref_table <- ReferenceTable$new(
+  name = "Parameters",
+  description = "Parameter lookup table",
+  key = key_column,
+  values = list(name_column, value_column)
+)
+
+# Save reference table definition
+result <- sp$items$save("ReferenceTable", ref_table)
+```
+
+## Loading Reference Tables
+
+```{r load-ref-tables}
+# Get all reference table names
+ref_table_names <- sp$items$load_names("ReferenceTable")
+
+# Load a specific reference table definition
+ref_table <- sp$items$load("ReferenceTable", "Parameters")
+```
+
+# Working with Pivot Tables
+
+Pivot tables define pre-aggregated summary tables.
+
+## Creating Pivot Tables
+
+```{r create-pivot}
+# Create a pivot table definition
+pivot_table <- PivotTable$new(
+  name = "Monthly Production Summary",
+  add_entity_alias_column = TRUE,
+  add_entity_type_column = TRUE,
+  scope_formula = 'Scope "Monthly"
+\tBetween #01/01/2024#
+\tAnd #12/31/2024#
+\tStep Monthly
+End Scope',
+  entity_set_formula = 'Entity Set "Production Wells"
+\t"Well-001"
+\t"Well-002"
+End Set',
+  table_formula = 'Table "Production"
+\tColumn "Oil" in "bbl/d"
+\t\t"Oil Rate" in "bbl/d"
+\tEnd Column
+End Table',
+  skip_empty_rows = TRUE,
+  add_is_opportunity_column = FALSE,
+  append_data = FALSE,
+  description = "Monthly production summary"
+)
+
+# Save pivot table definition
+result <- sp$items$save("PivotTable", pivot_table)
+```
+
+## Loading Pivot Tables
+
+```{r load-pivot}
+# Get all pivot table names
+pivot_names <- sp$items$load_names("PivotTable")
+
+# Load a specific pivot table definition
+pivot <- sp$items$load("PivotTable", "Monthly Production Summary")
+```
+
+# Advanced Operations
+
+## Batch Loading
+
+Load multiple items efficiently:
+
+```{r batch-load}
+# Get all entity names
+entity_names <- sp$items$load_names("Entity")
+
+# Load first 10 entities
+entities <- lapply(entity_names[1:10], function(name) {
+  sp$items$load("Entity", name)
+})
+
+# Extract information
+entity_info <- do.call(rbind, lapply(entities, function(e) {
+  data.frame(
+    name = e$name,
+    type = e$entity_type_name,
+    alias = if (is.null(e$alias)) NA else e$alias,
+    stringsAsFactors = FALSE
+  )
+}))
+
+print(entity_info)
+```
+
+## Searching and Filtering
+
+Manual filtering using R:
+
+```{r filtering}
+# Load all entity names
+all_entities <- sp$items$load_names("Entity")
+
+# Filter by pattern
+wells <- all_entities[grepl("^Well-", all_entities)]
+fields <- all_entities[grepl("Field", all_entities)]
+
+# Filter by multiple patterns
+production_assets <- all_entities[grepl("PROD|Well", all_entities)]
+
+# Case-insensitive search
+search_term <- "test"
+matching_entities <-
+  all_entities[grepl(search_term, all_entities, ignore.case = TRUE)]
+```
+
+## Exporting Repository Structure
+
+```{r export-structure}
+# Function to export entity structure
+export_entities <- function(sp) {
+  # Get all entities
+  entity_names <- sp$items$load_names("Entity")
+
+  # Load all entities
+  entities <- lapply(entity_names, function(name) {
+    tryCatch({
+      sp$items$load("Entity", name)
+    }, error = function(e) {
+      NULL
+    })
+  })
+
+  # Remove NULLs (failed loads)
+  entities <- entities[!sapply(entities, is.null)]
+
+  # Convert to data frame
+  entity_df <- do.call(rbind, lapply(entities, function(e) {
+    data.frame(
+      name = e$name,
+      type = e$entity_type_name,
+      alias = if (is.null(e$alias)) "" else e$alias,
+      is_opportunity = e$is_opportunity,
+      stringsAsFactors = FALSE
+    )
+  }))
+
+  return(entity_df)
+}
+
+# Export to CSV
+entity_export <- export_entities(sp)
+write.csv(entity_export, "entities.csv", row.names = FALSE)
+```
+
+## Bulk Creation
+
+```{r bulk-create}
+# Create multiple entities from a data frame
+entity_data <- data.frame(
+  name = c("Well-201", "Well-202", "Well-203"),
+  type = c("Well", "Well", "Well"),
+  alias = c("Producer 201", "Producer 202", "Injector 203"),
+  stringsAsFactors = FALSE
+)
+
+# Create and save entities
+for (i in 1:nrow(entity_data)) {
+  entity <- Entity$new(
+    name = entity_data$name[i],
+    entity_type_name = entity_data$type[i],
+    alias = entity_data$alias[i],
+    is_opportunity = FALSE
+  )
+
+  result <- sp$items$save("Entity", entity)
+
+  if (result$status_code == 201) {
+    cat("Created:", entity_data$name[i], "\n")
+  }
+}
+```
+
+# Best Practices
+
+## 1. Check Before Deleting
+
+```{r best-delete}
+# Check if item exists before deleting
+item_names <- sp$items$load_names("Entity")
+
+if ("Well-123" %in% item_names) {
+  sp$items$delete("Entity", "Well-123")
+  cat("Deleted Well-123\n")
+} else {
+  cat("Well-123 not found\n")
+}
+```
+
+## 2. Handle Errors Gracefully
+
+```{r best-errors}
+# Wrap operations in tryCatch
+result <- tryCatch({
+  entity <- sp$items$load("Entity", "NonExistent")
+  entity
+}, error = function(e) {
+  cat("Error loading entity:", e$message, "\n")
+  return(NULL)
+})
+
+if (!is.null(result)) {
+  # Process entity
+  cat("Loaded:", result$name, "\n")
+}
+```
+
+## 3. Validate Before Saving
+
+```{r best-validate}
+# Validate entity before saving
+create_validated_entity <- function(name, type, alias) {
+  # Check name
+  if (is.null(name) || name == "") {
+    stop("Entity name cannot be empty")
+  }
+
+  # Check type exists
+  types <- sp$items$load_names("EntityType")
+  if (!(type %in% types)) {
+    stop("Invalid entity type: ", type)
+  }
+
+  # Create entity
+  entity <- Entity$new(
+    name = name,
+    entity_type_name = type,
+    alias = alias,
+    is_opportunity = FALSE
+  )
+
+  return(entity)
+}
+
+# Use validation
+entity <- create_validated_entity("Well-999", "Well", "Test Well")
+result <- sp$items$save("Entity", entity)
+```
+
+## 4. Use Consistent Naming
+
+```{r best-naming}
+# Follow naming conventions
+# Good examples:
+# - "Well-001", "Well-002" (consistent numbering)
+# - "Field-North", "Field-South" (descriptive)
+
+# Create with naming function
+create_well_entity <- function(number, area) {
+  name <- sprintf("Well-%s-%03d", area, number)
+  alias <- sprintf("%s Area Well %d", area, number)
+
+  Entity$new(
+    name = name,
+    entity_type_name = "Well",
+    alias = alias,
+    is_opportunity = FALSE
+  )
+}
+
+# Use consistent naming
+well <- create_well_entity(1, "North")
+result <- sp$items$save("Entity", well)
+```
+
+# Item Type Reference
+
+Common item types you can work with:
+
+- **Entity**: Wells, fields, reservoirs, etc.
+- **EntityType**: Categories of entities
+- **Signal**: Measured or calculated values
+- **Unit**: Measurement units
+- **UnitMeasurement**: Unit categories
+- **Hierarchy**: Tree structures
+- **ReferenceTable**: Structured tables
+- **PivotTable**: Pre-aggregated tables
+- **Scenario**: Data versions
+- **Scope**: Entity and signal selections
+- **Tag**: Metadata tags
+- **MLModel**: Machine learning models
+- **RScript**: R scripts
+- **Workflow**: Automated processes
+
+# Important Notes
+
+## No Search or Filter Methods
+
+The repository service does **NOT** have these methods:
+- ❌ `load_by_filter()`
+- ❌ `load_by_name()` (use `load()` instead)
+- ❌ `search()`
+- ❌ `find()`
+
+You must use `load_names()` to get all names, then filter in R.
+
+## Signal Requirements
+
+When creating signals, you **must** provide all 13 required fields. Missing any field will cause an error.
+
+## Case Sensitivity
+
+Item names are case-sensitive. "Well-001" and "well-001" are different items.
+
+# Next Steps
+
+- **[Working with Data](working-with-data.html)**: Load and save data using repository items
+- **[Machine Learning](machine-learning.html)**: Use entities and signals in ML models
+- **[Getting Started](getting-started.html)**: Package overview
+
+# See Also
+
+- `?RepositoryService`: Complete repository service documentation
+- `?Entity`: Entity class documentation
+- `?Signal`: Signal class documentation
+- `?ServiceProvider`: Service provider documentation
+- Test files in `tests/testthat/test_entity.R` and `tests/testthat/test_signal.R` for examples

--- a/vignettes/working-with-data.Rmd
+++ b/vignettes/working-with-data.Rmd
@@ -1,0 +1,774 @@
+---
+title: "Working with Data Services"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Working with Data Services}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  eval = FALSE
+)
+```
+
+```{r setup}
+library(Myrconn.PetroVisor.Client)
+```
+
+# Overview
+
+The `DataServices` class provides comprehensive functionality for loading and saving various types of data in PetroVisor. This guide covers all data types, operations, and best practices based on tested examples.
+
+# Setup
+
+First, create a service provider instance:
+
+```{r service-provider}
+sp <- ServiceProvider$new(
+  url = "https://identity.us1.petrovisor.com",
+  workspace = "YourWorkspace",
+  user = "your_username",
+  password = "your_password"
+)
+
+# The data service is accessible via sp$data
+```
+
+# Data Types in PetroVisor
+
+PetroVisor supports several data types:
+
+1. **Static Data**: Entity-level data that doesn't vary with time or depth
+2. **Time Series Data**: Data that varies over time (TimeNumeric, TimeString)
+3. **Depth Data**: Data that varies with depth (DepthNumeric, DepthString)
+4. **PVT Data**: Pressure-Volume-Temperature dependent data
+5. **Reference Tables**: Structured tabular data with defined schemas
+6. **Pivot Tables**: Pre-aggregated summary tables
+
+# Loading Data with `load_signals()`
+
+The main method for loading data is `sp$data$load_signals()`. This method handles all data types.
+
+## Basic Loading Pattern
+
+```{r load-pattern}
+data <- sp$data$load_signals(
+  entities = c("Entity1", "Entity2"),     # Entity names
+  signals = list(signal1, signal2),        # Parsed signals
+  time_increment = "Daily",                # Time resolution
+  time_start = "2024-01-01T00:00:00",     # Start date/time
+  time_end = "2024-12-31T23:59:59",       # End date/time
+  reshape = TRUE                           # Reshape to wide format
+)
+```
+
+## Loading Time Series Data
+
+### Numeric Time Series
+
+```{r load-time-numeric}
+# Parse signal strings
+oil_rate <- sp$parse_signal("Oil Rate [bbl/d]")
+gas_rate <- sp$parse_signal("Gas Rate [Mscf/d]")
+water_rate <- sp$parse_signal("Water Rate [bbl/d]")
+
+# Load daily production data
+production <- sp$data$load_signals(
+  entities = c("Well-001", "Well-002", "Well-003"),
+  signals = list(oil_rate, gas_rate, water_rate),
+  time_increment = "Daily",
+  time_start = "2024-01-01T00:00:00",
+  time_end = "2024-12-31T23:59:59",
+  reshape = TRUE
+)
+
+# Result structure (when reshape = TRUE):
+# production$TimeNumericData is a data frame with columns:
+# - scenario
+# - date
+# - entity
+# - Oil Rate
+# - Gas Rate
+# - Water Rate
+
+head(production$TimeNumericData)
+```
+
+### String Time Series
+
+```{r load-time-string}
+# Load well status over time
+status_signal <- sp$parse_signal("Well Status [ ]")
+
+well_status <- sp$data$load_signals(
+  entities = c("Well-001"),
+  signals = list(status_signal),
+  time_increment = "Daily",
+  time_start = "2024-01-01T00:00:00",
+  time_end = "2024-12-31T23:59:59",
+  reshape = TRUE
+)
+
+# Result structure:
+# well_status$TimeStringData with columns:
+# - scenario, date, entity, Well Status
+```
+
+### Time Increments
+
+Available time increments:
+- `"Daily"` - Daily data points
+- `"Monthly"` - Monthly aggregates
+- `"Yearly"` - Yearly aggregates
+
+```{r time-increments}
+# Monthly production
+monthly_prod <- sp$data$load_signals(
+  entities = c("Well-001"),
+  signals = list(oil_rate),
+  time_increment = "Monthly",
+  time_start = "2024-01-01T00:00:00",
+  time_end = "2024-12-31T23:59:59",
+  reshape = TRUE
+)
+```
+
+## Loading Static Data
+
+Static data doesn't require time parameters:
+
+```{r load-static}
+# Parse static signals
+latitude <- sp$parse_signal("Latitude [deg]")
+longitude <- sp$parse_signal("Longitude [deg]")
+
+# Load static data (no time parameters needed)
+static_data <- sp$data$load_signals(
+  entities = c("Well-001", "Well-002", "Well-003"),
+  signals = list(latitude, longitude),
+  reshape = TRUE
+)
+
+# Result structure:
+# static_data$StaticNumericData with columns:
+# - scenario, entity, Latitude, Longitude
+```
+
+## Loading Depth Data
+
+Depth data varies with measured depth:
+
+```{r load-depth}
+# Parse depth signals
+porosity <- sp$parse_signal("Porosity [frac]")
+permeability <- sp$parse_signal("Permeability [mD]")
+
+# Load depth data
+depth_data <- sp$data$load_signals(
+  entities = c("Well-001"),
+  signals = list(porosity, permeability),
+  depth_increment = "Meter",
+  depth_start = 5000,
+  depth_end = 7000,
+  reshape = TRUE
+)
+
+# Result structure:
+# depth_data$DepthNumericData with columns:
+# - scenario, depth, entity, Porosity, Permeability
+```
+
+## Loading PVT Data
+
+PVT data depends on pressure and temperature:
+
+```{r load-pvt}
+# PVT signals
+oil_fvf <- sp$parse_signal("Oil FVF [rb/stb]")
+gas_fvf <- sp$parse_signal("Gas FVF [rcf/scf]")
+
+# Load PVT data
+pvt_data <- sp$data$load_signals(
+  entities = c("Reservoir-A"),
+  signals = list(oil_fvf, gas_fvf),
+  pressure_unit = "psi",
+  temperature_unit = "degC",
+  reshape = TRUE
+)
+
+# Result structure:
+# pvt_data$PVTNumericData with columns:
+# - scenario, pressure, temperature, entity, Oil FVF, Gas FVF
+```
+
+## Loading Reference Tables
+
+Reference tables are loaded separately:
+
+```{r load-reference-table}
+# Load a reference table by name
+decline_curve <- sp$data$load_reference_table("Decline Curve Parameters")
+
+# Result is a data frame with the table structure
+head(decline_curve)
+```
+
+## Loading Pivot Tables
+
+```{r load-pivot}
+# Load a pivot table
+summary <- sp$data$load_pivot_table("Monthly Production Summary")
+
+# Optionally limit number of rows
+summary_limited <- sp$data$load_pivot_table("Monthly Production Summary", 100)
+```
+
+## Data Reshaping
+
+The `reshape` parameter controls output format:
+
+```{r reshape-comparison}
+# reshape = FALSE (long format - raw API response)
+long_data <- sp$data$load_signals(
+  entities = c("Well-001"),
+  signals = list(oil_rate, gas_rate),
+  time_increment = "Daily",
+  time_start = "2024-01-01T00:00:00",
+  time_end = "2024-01-31T23:59:59",
+  reshape = FALSE
+)
+# Structure: list with raw API response
+
+# reshape = TRUE (wide format - user-friendly)
+wide_data <- sp$data$load_signals(
+  entities = c("Well-001"),
+  signals = list(oil_rate, gas_rate),
+  time_increment = "Daily",
+  time_start = "2024-01-01T00:00:00",
+  time_end = "2024-01-31T23:59:59",
+  reshape = TRUE
+)
+# Structure: list with reshaped data frames
+# wide_data$TimeNumericData has columns:
+# - scenario
+# - date
+# - entity
+# - Oil Rate
+# - Gas Rate
+```
+
+# Saving Data with `save_signals()`
+
+The main method for saving data is `sp$data$save_signals()`.
+
+## Saving Time Series Data
+
+### Numeric Time Series
+
+```{r save-time-numeric}
+# Prepare data frame with correct column names
+time_numeric_data <- data.frame(
+  scenario = c("", ""),
+  date = c("2024-01-01T00:00:00", "2024-01-02T00:00:00"),
+  entity = c("Well-001", "Well-001"),
+  oil_rate = c(500, 520),
+  gas_rate = c(1500, 1560)
+)
+
+# Column names must match signal names (without units)
+colnames(time_numeric_data) <- c(
+  "scenario", "date", "entity",
+  "Oil Rate", "Gas Rate"
+)
+
+# Parse signals (with units)
+oil_signal <- sp$parse_signal("Oil Rate [bbl/d]")
+gas_signal <- sp$parse_signal("Gas Rate [Mscf/d]")
+
+# Save data using correct data type name
+result <- sp$data$save_signals(
+  "TimeNumeric",  # Data type name
+  time_numeric_data,
+  signals = list(oil_signal, gas_signal)
+)
+
+# Check result
+if (result$status_code == 200) {
+  cat("Data saved successfully!\n")
+}
+```
+
+### String Time Series
+
+```{r save-time-string}
+# Prepare string data
+time_string_data <- data.frame(
+  scenario = c(""),
+  date = c("2024-01-01T00:00:00"),
+  entity = c("Well-001"),
+  status = c("Producing")
+)
+
+colnames(time_string_data) <- c(
+  "scenario", "date", "entity",
+  "Well Status"
+)
+
+# Save string data
+status_signal <- sp$parse_signal("Well Status [ ]")
+result <- sp$data$save_signals(
+  "TimeString",
+  time_string_data,
+  signals = list(status_signal)
+)
+```
+
+## Saving Static Data
+
+```{r save-static}
+# Prepare static data
+static_data <- data.frame(
+  scenario = c("", ""),
+  entity = c("Well-001", "Well-002"),
+  latitude = c(45.123, 45.234),
+  longitude = c(-110.456, -110.567)
+)
+
+colnames(static_data) <- c(
+  "scenario", "entity",
+  "Latitude", "Longitude"
+)
+
+# Parse signals
+lat_signal <- sp$parse_signal("Latitude [deg]")
+lon_signal <- sp$parse_signal("Longitude [deg]")
+
+# Save static data
+result <- sp$data$save_signals(
+  "StaticNumeric",
+  static_data,
+  signals = list(lat_signal, lon_signal)
+)
+```
+
+## Saving Depth Data
+
+```{r save-depth}
+# Prepare depth data
+depth_data <- data.frame(
+  scenario = c("", ""),
+  entity = c("Well-001", "Well-001"),
+  depth = c(5000, 5001),
+  porosity = c(0.15, 0.16),
+  permeability = c(50, 55)
+)
+
+colnames(depth_data) <- c(
+  "scenario", "entity", "depth",
+  "Porosity", "Permeability"
+)
+
+# Save depth data
+por_signal <- sp$parse_signal("Porosity [frac]")
+perm_signal <- sp$parse_signal("Permeability [mD]")
+
+result <- sp$data$save_signals(
+  "DepthNumeric",
+  depth_data,
+  signals = list(por_signal, perm_signal)
+)
+```
+
+## Saving PVT Data
+
+```{r save-pvt}
+# Prepare PVT data
+pvt_data <- data.frame(
+  scenario = c("", ""),
+  temperature = c(100, 100),
+  pressure = c(150, 200),
+  entity = c("Reservoir-A", "Reservoir-A"),
+  oil_fvf = c(1.15, 1.20),
+  gas_fvf = c(0.005, 0.006)
+)
+
+colnames(pvt_data) <- c(
+  "scenario", "temperature", "pressure", "entity",
+  "Oil FVF", "Gas FVF"
+)
+
+# Save PVT data
+oil_fvf_signal <- sp$parse_signal("Oil FVF [rb/stb]")
+gas_fvf_signal <- sp$parse_signal("Gas FVF [rcf/scf]")
+
+result <- sp$data$save_signals(
+  "PVTNumeric",
+  pvt_data,
+  signals = list(oil_fvf_signal, gas_fvf_signal),
+  pressure_unit = "psi",
+  temperature_unit = "degC"
+)
+```
+
+## Saving Reference Tables
+
+```{r save-reference-table}
+# Prepare reference table data
+ref_table_data <- data.frame(
+  Entity = c(NA, "Well-001", NA, "Well-001"),
+  Timestamp = c(NA, "2024-01-01T00:00:00", NA, NA),
+  ID = c(1, 2, 3, 4),
+  Name = c("Param1", "Param2", "Param3", "Param4"),
+  Value = c(100, 200, 300, 400)
+)
+
+# Save reference table data
+result <- sp$data$save_reference_table("Parameters", ref_table_data)
+```
+
+## Saving Pivot Tables
+
+```{r save-pivot}
+# Pivot tables are generated/saved using their definitions
+# No direct data saving - data is generated by the pivot table formula
+result <- sp$data$save_pivot_table("Monthly Production Summary")
+```
+
+## Handling Missing Values
+
+Use `NA` or `NaN` for missing numeric values:
+
+```{r missing-values}
+# Data with missing values
+data_with_na <- data.frame(
+  scenario = c("", "", ""),
+  date = c("2024-01-01T00:00:00", "2024-01-02T00:00:00", "2024-01-03T00:00:00"),
+  entity = c("Well-001", "Well-001", "Well-001"),
+  oil_rate = c(500, NA, 520),  # Missing value on Jan 2
+  gas_rate = c(1500, 1550, NaN)  # NaN on Jan 3
+)
+
+colnames(data_with_na) <- c(
+  "scenario", "date", "entity",
+  "Oil Rate", "Gas Rate"
+)
+
+# PetroVisor handles NA/NaN appropriately
+result <- sp$data$save_signals("TimeNumeric", data_with_na, signals)
+```
+
+# Deleting Data
+
+## Delete Signal Data
+
+```{r delete-signals}
+# Delete specific signal data for entities
+result <- sp$data$delete_signals(
+  entities = c("Well-001", "Well-002"),
+  signals = c("Oil Rate", "Gas Rate"),  # Signal names without units
+  time_start = "2024-01-01T00:00:00",
+  time_end = "2024-01-31T23:59:59"
+)
+```
+
+## Delete Reference Table Data
+
+```{r delete-reference}
+# Delete all data
+result <- sp$data$delete_reference_table("Parameters")
+
+# Delete with WHERE clause
+result <- sp$data$delete_reference_table(
+  "Parameters",
+  where = "[Value] > 200"
+)
+```
+
+## Delete Pivot Table Data
+
+```{r delete-pivot}
+result <- sp$data$delete_pivot_table("Monthly Production Summary")
+```
+
+# Working with Signals and Units
+
+## Signal Parsing
+
+PetroVisor signals are strings that combine name and unit:
+
+```{r signal-parsing}
+# Parse a signal string (format: "Name [unit]")
+signal <- sp$parse_signal("Oil Production Rate [bbl/d]")
+
+# Access components
+signal$Signal  # "Oil Production Rate"
+signal$Unit    # "bbl/d"
+
+# Use in data operations
+data <- sp$data$load_signals(
+  entities = c("Well-001"),
+  signals = list(signal),
+  time_increment = "Daily",
+  time_start = "2024-01-01T00:00:00",
+  time_end = "2024-01-31T23:59:59",
+  reshape = TRUE
+)
+```
+
+## Unit Conversion
+
+Convert data between units:
+
+```{r unit-conversion}
+# Load data in bbl/d
+oil_data <- sp$data$load_signals(
+  entities = c("Well-001"),
+  signals = list(sp$parse_signal("Oil Rate [bbl/d]")),
+  time_increment = "Daily",
+  time_start = "2024-01-01T00:00:00",
+  time_end = "2024-01-31T23:59:59",
+  reshape = TRUE
+)
+
+# Convert oil rate column from bbl/d to m3/d
+oil_data$TimeNumericData$`Oil Rate` <- sp$convert_unit(
+  x = oil_data$TimeNumericData$`Oil Rate`,
+  source_unit = "bbl/d",
+  target_unit = "m3/d"
+)
+
+# Now oil_data has rates in m3/d
+```
+
+## Special Unit Characters
+
+Some units require special handling:
+
+```{r special-units}
+# Space as unit (dimensionless)
+dimensionless <- sp$parse_signal("Recovery Factor [ ]")
+
+# Percent
+percentage <- sp$parse_signal("Water Cut [%]")
+
+# Converting percent to fraction
+fraction <- sp$convert_unit(10, "%", " ")  # Result: 0.1
+
+# Converting fraction to percent
+percent <- sp$convert_unit(0.1, " ", "%")  # Result: 10
+
+# Units with slashes are handled automatically
+rate <- sp$parse_signal("Production Rate [bbl/d]")
+pressure_rate <- sp$parse_signal("Pressure Gradient [psi/ft]")
+```
+
+# Advanced Data Operations
+
+## Batch Loading Multiple Entities
+
+```{r batch-load}
+# Get list of entities
+all_wells <- sp$items$load_names("Entity")
+
+# Filter to wells of interest
+production_wells <- all_wells[grepl("^PROD-", all_wells)]
+
+# Load data for all production wells
+all_production <- sp$data$load_signals(
+  entities = production_wells,
+  signals = list(
+    sp$parse_signal("Oil Rate [bbl/d]"),
+    sp$parse_signal("Gas Rate [Mscf/d]"),
+    sp$parse_signal("Water Rate [bbl/d]")
+  ),
+  time_increment = "Monthly",
+  time_start = "2024-01-01T00:00:00",
+  time_end = "2024-12-31T23:59:59",
+  reshape = TRUE
+)
+```
+
+## Limiting Results with `top_records`
+
+```{r top-records}
+# Load only the first 10 records
+limited_data <- sp$data$load_signals(
+  entities = c("Well-001"),
+  signals = list(sp$parse_signal("Oil Rate [bbl/d]")),
+  time_increment = "Daily",
+  time_start = "2024-01-01T00:00:00",
+  time_end = "2024-12-31T23:59:59",
+  top_records = 10,
+  reshape = TRUE
+)
+```
+
+## Working with Scenarios
+
+```{r scenarios}
+# Load data from specific scenarios
+scenario_data <- sp$data$load_signals(
+  entities = c("Well-001"),
+  signals = list(sp$parse_signal("Oil Rate [bbl/d]")),
+  scenario_names = c("Base Case", "Optimistic"),
+  time_increment = "Monthly",
+  time_start = "2024-01-01T00:00:00",
+  time_end = "2024-12-31T23:59:59",
+  include_workspace_data = TRUE,
+  reshape = TRUE
+)
+```
+
+# Data Type Names Reference
+
+When using `save_signals()`, use these exact data type names:
+
+- **Static data**: `"StaticNumeric"`, `"StaticString"`
+- **Time series**: `"TimeNumeric"`, `"TimeString"`
+- **Depth data**: `"DepthNumeric"`, `"DepthString"`
+- **PVT data**: `"PVTNumeric"`
+
+# Best Practices
+
+## 1. Always Parse Signals
+
+```{r best-parse}
+# GOOD - Parse signal strings
+signal <- sp$parse_signal("Oil Rate [bbl/d]")
+data <- sp$data$load_signals(entities = wells, signals = list(signal), ...)
+
+# Avoid manually constructing signal objects
+```
+
+## 2. Use Correct Date Format
+
+```{r best-dates}
+# GOOD - ISO 8601 format
+time_start <- "2024-01-01T00:00:00"
+time_end <- "2024-12-31T23:59:59"
+
+# BAD - Other formats will fail
+# time_start <- "2024-01-01"
+# time_start <- "01/01/2024"
+```
+
+## 3. Match Column Names to Signals
+
+```{r best-columns}
+# Signal name: "Oil Rate [bbl/d]"
+# Column name in data frame: "Oil Rate" (without unit)
+
+data <- data.frame(
+  scenario = c(""),
+  date = c("2024-01-01T00:00:00"),
+  entity = c("Well-001"),
+  oil_rate = c(500)
+)
+
+# Set column name to match signal name (without unit)
+colnames(data)[4] <- "Oil Rate"
+
+# Now save with signal including unit
+result <- sp$data$save_signals(
+  "TimeNumeric",
+  data,
+  signals = list(sp$parse_signal("Oil Rate [bbl/d]"))
+)
+```
+
+## 4. Handle Errors Gracefully
+
+```{r best-errors}
+# Wrap data operations in tryCatch
+result <- tryCatch({
+  sp$data$save_signals(
+    "TimeNumeric",
+    my_data,
+    signals = my_signals
+  )
+}, error = function(e) {
+  cat("Error saving data:", e$message, "\n")
+  return(list(status_code = 500))
+})
+
+if (result$status_code == 200) {
+  cat("Data saved successfully\n")
+}
+```
+
+## 5. Check Data Structure Before Saving
+
+```{r best-check}
+# Validate data structure
+str(data_to_save)
+head(data_to_save)
+
+# Check column names match signals (without units)
+expected_cols <- c("scenario", "date", "entity", "Oil Rate", "Gas Rate")
+actual_cols <- colnames(data_to_save)
+
+if (!all(expected_cols %in% actual_cols)) {
+  stop("Column names don't match expected signal names")
+}
+
+# Check for missing values
+cat("Missing values per column:\n")
+print(colSums(is.na(data_to_save)))
+
+# Then save
+result <- sp$data$save_signals(...)
+```
+
+# Common Issues and Solutions
+
+## Issue: "Column not found" error
+
+**Cause**: Column names in data frame don't match signal names
+
+**Solution**: Ensure column names exactly match signal names (without units)
+
+```{r fix-columns}
+# If signal is "Oil Rate [bbl/d]", column must be "Oil Rate"
+colnames(my_data)[which(colnames(my_data) == "oil_rate")] <- "Oil Rate"
+```
+
+## Issue: "Invalid date format" error
+
+**Cause**: Date not in ISO 8601 format
+
+**Solution**: Use `"YYYY-MM-DDTHH:MM:SS"` format
+
+```{r fix-dates}
+# Convert dates to correct format
+my_data$date <- format(as.POSIXct(my_data$date), "%Y-%m-%dT%H:%M:%S")
+```
+
+## Issue: Data not appearing after save
+
+**Cause**: Wrong data type name used
+
+**Solution**: Use correct data type name (e.g., "TimeNumeric" not "Time")
+
+```{r fix-datatype}
+# CORRECT
+result <- sp$data$save_signals("TimeNumeric", data, signals)
+
+# INCORRECT
+# result <- sp$data$save_signals("Time", data, signals)
+```
+
+# Next Steps
+
+- **[Repository Service](repository-service.html)**: Learn about creating signals and entities
+- **[Machine Learning](machine-learning.html)**: Use your data for ML models
+- **[Getting Started](getting-started.html)**: Package overview
+
+# See Also
+
+- `?DataServices`: Complete data services documentation
+- `?ServiceProvider`: Service provider documentation
+- Test files in `tests/testthat/test_data_services.R` for more examples


### PR DESCRIPTION
* add `send_mail()` method to `ServiceProvider` class for sending emails using PetroVisor email configuration
* deprecate `DataSetRequest` class - never integrated into DataServices, use DataServices methods directly instead
* add comprehensive documentation with @seealso cross-references and vignette integration across all major classes