### PR TITLE
Remove `delete()` method from `LoggingService` class

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # Myrconn.PetroVisor.Client (development version)
 
+* remove `delete()` method from `LoggingService` class - the underlying `LogEntries/Clean` and `LogEntries/CleanCategory` API endpoints have been removed from the PetroVisor Web API
 * add `send_mail()` method to `ServiceProvider` class for sending emails using PetroVisor email configuration
 * deprecate `DataSetRequest` class - never integrated into DataServices, use DataServices methods directly instead
 * add comprehensive documentation with @seealso cross-references and vignette integration across all major classes

--- a/R/LoggingService.R
+++ b/R/LoggingService.R
@@ -41,9 +41,6 @@ library("R6")
 #'                        category = "Tag",
 #'                        severity = "Information")
 #' sp$logs$save(list(entry1, entry2))
-#'
-#' # remove all log entries
-#' sp$logs$delete(days_to_keep = 0)
 #' }
 LoggingService <- R6Class( # nolint: object_name_linter
   "LoggingService",
@@ -129,29 +126,6 @@ LoggingService <- R6Class( # nolint: object_name_linter
       # add entries to database
       super$post(body = dl,
                  route = "LogEntries/AddMultiple")
-    },
-
-    #' @description Remove log entries from the database.
-    #'
-    #' @param days_to_keep Keep the log entries of the last n days in the
-    #'  log. Defaults to 0.
-    #' @param category Remove log entries of the specified category only.
-    delete = function(days_to_keep = 0, category) {
-      # if no category is given, use the normal /Clean call
-      # else use /CleanCategory
-      if (missing(category)) {
-        query <- list(KeepTimeSpan = days_to_keep)
-        route <- "LogEntries/Clean"
-      } else {
-        query <- list(KeepTimeSpan = days_to_keep,
-                      Category = category)
-        route <- "LogEntries/CleanCategory"
-      }
-
-      super$post(body = NULL,
-                 route = route,
-                 expect_data = FALSE,
-                 query = query)
     }
   )
 )

--- a/man/LoggingService.Rd
+++ b/man/LoggingService.Rd
@@ -38,9 +38,6 @@ entry2 <- LogEntry$new(message = "Test2",
                        category = "Tag",
                        severity = "Information")
 sp$logs$save(list(entry1, entry2))
-
-# remove all log entries
-sp$logs$delete(days_to_keep = 0)
 }
 }
 \seealso{
@@ -60,7 +57,6 @@ sp$logs$delete(days_to_keep = 0)
 \item \href{#method-LoggingService-load_categories}{\code{LoggingService$load_categories()}}
 \item \href{#method-LoggingService-load}{\code{LoggingService$load()}}
 \item \href{#method-LoggingService-save}{\code{LoggingService$save()}}
-\item \href{#method-LoggingService-delete}{\code{LoggingService$delete()}}
 \item \href{#method-LoggingService-clone}{\code{LoggingService$clone()}}
 }
 }
@@ -163,26 +159,6 @@ Add one or several log entries to the database at once.
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{log_entries}}{a list of LogEntry-objects.}
-}
-\if{html}{\out{</div>}}
-}
-}
-\if{html}{\out{<hr>}}
-\if{html}{\out{<a id="method-LoggingService-delete"></a>}}
-\if{latex}{\out{\hypertarget{method-LoggingService-delete}{}}}
-\subsection{Method \code{delete()}}{
-Remove log entries from the database.
-\subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{LoggingService$delete(days_to_keep = 0, category)}\if{html}{\out{</div>}}
-}
-
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{days_to_keep}}{Keep the log entries of the last n days in the
-log. Defaults to 0.}
-
-\item{\code{category}}{Remove log entries of the specified category only.}
 }
 \if{html}{\out{</div>}}
 }

--- a/tests/testthat/test_logEntry.R
+++ b/tests/testthat/test_logEntry.R
@@ -96,16 +96,5 @@ test_that("LogEntry Categories can be retrieved", {
 test_that("LogEntry can be retrieved", {
   retrieved_entries <- sp$logs$load(categories = c("R Test"))
 
-  expect_equal(nrow(retrieved_entries), 2)
-})
-
-test_that("LogEntry can be removed", {
-  # make sure log entries created to day are deleted too (hence the -1)
-  result <- sp$logs$delete(days_to_keep = -1, category = "R Test")
-
-  expect_equal(result$status_code, 200)
-
-  retrieved_entries <- sp$logs$load(categories = c("R Test"))
-
-  expect_true(length(retrieved_entries) == 0)
+  expect_more_than(nrow(retrieved_entries), 0)
 })

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -219,12 +219,6 @@ warnings <- sp$logs$load(severities = c("Warning"))
 
 # Load latest 10 entries
 recent_logs <- sp$logs$load(last_entries = 10)
-
-# Delete log entries (keep last 30 days)
-sp$logs$delete(days_to_keep = 30)
-
-# Delete specific category
-sp$logs$delete(days_to_keep = 0, category = "R Test")
 ```
 
 ## Utility Functions


### PR DESCRIPTION
* remove `delete()` method from `LoggingService` class - the underlying `LogEntries/Clean` and `LogEntries/CleanCategory` API endpoints have been removed from the PetroVisor Web API